### PR TITLE
add: java客户端添加基于byte[]的数据库读取方式

### DIFF
--- a/binding/java/src/org/lionsoul/ip2region/DBReader.java
+++ b/binding/java/src/org/lionsoul/ip2region/DBReader.java
@@ -1,0 +1,14 @@
+package org.lionsoul.ip2region;
+
+import java.io.IOException;
+
+public interface DBReader {
+
+    byte[] full() throws IOException;
+
+    void seek(long pos) throws IOException;
+
+    void readFully(byte[] buf, int offset, int length) throws IOException;
+
+    void close() throws IOException;
+}

--- a/binding/java/src/org/lionsoul/ip2region/impl/ByteArrayDBReader.java
+++ b/binding/java/src/org/lionsoul/ip2region/impl/ByteArrayDBReader.java
@@ -1,0 +1,38 @@
+package org.lionsoul.ip2region.impl;
+
+import java.io.IOException;
+
+import org.lionsoul.ip2region.DBReader;
+
+/**
+ * 把一个byte[]当成ip2region的数据库文件
+ * @author wendal(wendal1985@gmail.com)
+ *
+ */
+public class ByteArrayDBReader implements DBReader {
+
+    protected byte[] buf;
+
+    protected long pos;
+
+    public ByteArrayDBReader(byte[] buf) {
+        this.buf = buf;
+    }
+
+    public byte[] full() throws IOException {
+        return buf;
+    }
+
+    public void seek(long pos) throws IOException {
+        this.pos = pos;
+    }
+
+    public void readFully(byte[] buf, int offset, int length) throws IOException {
+        System.arraycopy(this.buf, (int) pos, buf, offset, length);
+    }
+
+    public void close() throws IOException {
+        // nop
+    }
+
+}

--- a/binding/java/src/org/lionsoul/ip2region/impl/RandomAccessFileDBReader.java
+++ b/binding/java/src/org/lionsoul/ip2region/impl/RandomAccessFileDBReader.java
@@ -1,0 +1,38 @@
+package org.lionsoul.ip2region.impl;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+
+import org.lionsoul.ip2region.DBReader;
+
+/**
+ * 把一个RandomAccessFile当成ip2region的数据库文件,即兼容原本的行为
+ * @author wendal(wendal1985@gmail.com)
+ *
+ */
+public class RandomAccessFileDBReader implements DBReader {
+
+    protected RandomAccessFile raf;
+
+    public RandomAccessFileDBReader(RandomAccessFile raf) {
+        this.raf = raf;
+    }
+
+    public byte[] full() throws IOException {
+        byte[] buf = new byte[(int) raf.length()];
+        raf.readFully(buf, 0, buf.length);
+        return buf;
+    }
+
+    public void seek(long pos) throws IOException {
+        raf.seek(pos);
+    }
+
+    public void readFully(byte[] buf, int offset, int length) throws IOException {
+        raf.readFully(buf, offset, length);
+    }
+
+    public void close() throws IOException {
+        raf.close();
+    }
+}


### PR DESCRIPTION
add: java客户端添加基于byte[]的数据库读取方式,摆脱本地文件的困扰

测试代码

```java
    @Test
    public void testMemorySearchString() throws IOException {
        DBReader reader = new ByteArrayDBReader(Streams.readBytes(getClass().getClassLoader().getResourceAsStream("ip2region/ip2region.db")));
        DbSearcher searcher = new DbSearcher(null, reader);
        
        String ip = searcher.memorySearch("219.136.76.152").getRegion();
        System.out.println(ip);

        ip = searcher.btreeSearch("219.136.76.152").getRegion();
        System.out.println(ip);
        
        ip = searcher.binarySearch("219.136.76.152").getRegion();
        System.out.println(ip);
    }
```