### PR TITLE
fix: ReferenceError: m is not defined

### DIFF
--- a/binding/nodejs/ip2region.js
+++ b/binding/nodejs/ip2region.js
@@ -121,7 +121,7 @@ ip2region.btreeSearchSync = function(ip)
         mid = ((low + high) >> 1);
         
         if (ip == headerSip[mid]) {
-            if ( m > 0) {
+            if ( mid > 0) {
                 sptr = headerPtr[mid - 1];
                 eptr = headerPtr[mid];
             } else {


### PR DESCRIPTION
m 是个为定义的变量.  当传入 ip 是个空字符串的时候会触发bug