### PR TITLE
Rust: 0.2.0, use std::net::Ipaddr and update Error.

### DIFF
--- a/binding/rust/Cargo.toml
+++ b/binding/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ip2region"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["biluohc <biluohc@qq.com>"]
 
 include = ["./*", "../../data/ip2region.db", "../../Cargo.toml"]

--- a/binding/rust/example/src/main.rs
+++ b/binding/rust/example/src/main.rs
@@ -27,6 +27,19 @@ fn lazy() {
         let res = memory_search(ip);
         let end = start.elapsed().subsec_micros();
         println!("lazy__ {:06} microseconds: {:?}", end, res);
+
+        let start = Instant::now();
+        let ip_addr = ip.parse().unwrap();
+        let res2 = memory_search_ip(&ip_addr);
+        let end = start.elapsed().subsec_micros();
+        println!("lazy__ {:06} microseconds: {:?}", end, res2);
+
+        if res.is_ok() && res2.is_ok() {
+            assert_eq!(res.unwrap(), res2.unwrap());
+        } else if res.is_err() && res2.is_err() {
+        } else {
+            panic!("not EQ")
+        }
     }
 }
 
@@ -38,21 +51,64 @@ fn overview() {
     let ip2o = ip2.to_owned().unwrap();
 
     for ip in IPS {
+        // mem
         let start = Instant::now();
         let res = ip2o.memory_search(ip);
         let end = start.elapsed().subsec_micros();
         println!("memory {:06} microseconds: {:?}", end, res);
 
         let start = Instant::now();
+        let ip_addr = ip.parse().unwrap();
+        let res2 = ip2o.memory_search_ip(&ip_addr);
+        let end = start.elapsed().subsec_micros();
+        println!("memory {:06} microseconds: {:?}", end, res2);
+
+        if res.is_ok() && res2.is_ok() {
+            assert_eq!(res.unwrap(), res2.unwrap());
+        } else if res.is_err() && res2.is_err() {
+        } else {
+            panic!("not EQ")
+        }
+
+        // binary
+        let start = Instant::now();
         let res = ip2.binary_search(ip);
         let end = start.elapsed().subsec_micros();
         println!("binary {:06} microseconds: {:?}", end, res);
 
         let start = Instant::now();
+        let ip_addr = ip.parse().unwrap();
+        let res2 = ip2.binary_search_ip(&ip_addr);
+        let end = start.elapsed().subsec_micros();
+        println!("binary {:06} microseconds: {:?}", end, res2);
+
+        if res.is_ok() && res2.is_ok() {
+            assert_eq!(res.unwrap(), res2.unwrap());
+        } else if res.is_err() && res2.is_err() {
+        } else {
+            panic!("not EQ")
+        }
+
+        // btree
+        let start = Instant::now();
         let res = ip2.btree_search(ip);
         let end = start.elapsed().subsec_micros();
         println!("btree  {:06} microseconds: {:?}", end, res);
 
+        let start = Instant::now();
+        let ip_addr = ip.parse().unwrap();
+        let res2 = ip2.btree_search_ip(&ip_addr);
+        let end = start.elapsed().subsec_micros();
+        println!("btree_ {:06} microseconds: {:?}", end, res2);
+
+        if res.is_ok() && res2.is_ok() {
+            assert_eq!(res.unwrap(), res2.unwrap());
+        } else if res.is_err() && res2.is_err() {
+        } else {
+            panic!("not EQ")
+        }
+
+        // \n
         println!();
     }
 }

--- a/binding/rust/readme.md
+++ b/binding/rust/readme.md
@@ -2,9 +2,11 @@
 
 ## 用法
 
-都在 `src/example` 里
+Demo： 在 `example` 目录里
 
-另外 `cargo doc --features lazy` 可以看到所有 `API`。
+API文档： `cargo doc --features lazy --open` 可以看到所有。 
+
+运行测试： `cargo test --features lazy` 
 
 ### 添加依赖
 
@@ -20,11 +22,11 @@ version = "*"
 ```
 
 ### 代码
-查看 `src/example/src/main.rs` 
+查看 `example/src/main.rs` 
 
 ### `lazy` feature 把 DB 直接打包进二进制
 
-取消上面 toml 的 `# features = ["lazy"]` 行的注释即可使用，其 api 是 `memory_search`。
+取消上面 toml 的 `# features = ["lazy"]` 行的注释即可使用，其 api 是 `memory_search` 和  `memory_search_ip`。
 
 只是目前 DB 足有3.2M，还是有些感人的。
 

--- a/binding/rust/src/error.rs
+++ b/binding/rust/src/error.rs
@@ -1,20 +1,31 @@
-use std::{self, io, num, str};
+use std::{self, io, net, str};
 
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug)]
 pub enum Error {
-    Str(&'static str),
     Io(io::Error),
     Utf8(str::Utf8Error),
-    Int(num::ParseIntError),
+    Addr(net::AddrParseError),
+    /// `224.0.0.0` ~ `239.255.255.255`
+    ///
+    // `ff00::/8`
+    IpIsMulticast,
+    /// `0.0.0.0`
+    IpIsUnspecified,
+    /// `127.0.0.0/8`
+    IpIsLoopback,
+    ///1. `10.0.0.0/8`
+    ///
+    ///2. `172.16.0.0/12`
+    ///
+    ///3. `192.168.0.0/16`
+    IpIsPrivate,
+    /// Unsupport Ipv6 Now
+    UnsupportIpv6,
+    NotFound,
 }
 
-impl From<&'static str> for Error {
-    fn from(e: &'static str) -> Self {
-        Error::Str(e)
-    }
-}
 impl From<io::Error> for Error {
     fn from(e: io::Error) -> Self {
         Error::Io(e)
@@ -25,8 +36,9 @@ impl From<str::Utf8Error> for Error {
         Error::Utf8(e)
     }
 }
-impl From<num::ParseIntError> for Error {
-    fn from(e: num::ParseIntError) -> Self {
-        Error::Int(e)
+
+impl From<net::AddrParseError> for Error {
+    fn from(e: net::AddrParseError) -> Self {
+        Error::Addr(e)
     }
 }

--- a/binding/rust/src/lazy.rs
+++ b/binding/rust/src/lazy.rs
@@ -11,6 +11,10 @@ lazy_static! {
     };
 }
 
-pub fn memory_search(ip_str: &str) -> Result<IpInfo> {
+pub fn memory_search<S: AsRef<str>>(ip_str: S) -> Result<IpInfo<'static>> {
     OWNED_IP_2_REGION.memory_search(ip_str)
+}
+
+pub fn memory_search_ip(ip_addr: &IpAddr) -> Result<IpInfo> {
+    OWNED_IP_2_REGION.memory_search_ip(ip_addr)
 }

--- a/binding/rust/src/owned.rs
+++ b/binding/rust/src/owned.rs
@@ -65,8 +65,13 @@ impl OwnedIp2Region {
         })
     }
 
-    pub fn memory_search(&self, ip_str: &str) -> Result<IpInfo> {
-        let ip = ip2u32(ip_str)?;
+    pub fn memory_search<S: AsRef<str>>(&self, ip_str: S) -> Result<IpInfo> {
+        let ip = ip_str.as_ref().parse()?;
+        self.memory_search_ip(&ip)
+    }
+
+    pub fn memory_search_ip(&self, ip_addr: &IpAddr) -> Result<IpInfo> {
+        let ip = ip2u32(ip_addr)?;
         let mut h = self.total_blocks;
         let (mut data_ptr, mut l) = (0u32, 0u32);
         while l <= h {
@@ -88,7 +93,7 @@ impl OwnedIp2Region {
         }
 
         if data_ptr == 0 {
-            Err("not found")?;
+            Err(Error::NotFound)?;
         }
 
         let data_len = (data_ptr >> 24) & 0xff;


### PR DESCRIPTION
非常抱歉，上次只忙着翻译API了。

这次考虑到Rust里的IP地址基本都是具体类型的`IpAddr`, 要格式化成字符串也是不小的开销，所以加个`xxx_search_ip`的`API`直接兼容`IpAddr类型的。

另外标准库里自带的 `IpAddr`有`API`过滤掉v6、'0.0.0.0'、多播、回环和局域网地址。

`Error`错误枚举类型也更为详细。

测试和 demo 也在readme里提及了。