### PR TITLE
[Fix] Add "Disposible" interface for final release of resouces

### DIFF
--- a/binding/c#/IP2Region.Test.Benchmark/DbSearch_Test.cs
+++ b/binding/c#/IP2Region.Test.Benchmark/DbSearch_Test.cs
@@ -1,9 +1,5 @@
 ﻿using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Order;
 using IP2Region.Models;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace IP2Region.Test.Benchmark

--- a/binding/c#/IP2Region.Test.Benchmark/TestBase.cs
+++ b/binding/c#/IP2Region.Test.Benchmark/TestBase.cs
@@ -1,7 +1,5 @@
 ﻿using BenchmarkDotNet.Attributes;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace IP2Region.Test.Benchmark
 {
@@ -17,7 +15,7 @@ namespace IP2Region.Test.Benchmark
 
         public TestBase(String DBFilePath)
         {
-            this._dBFilePath = DBFilePath;
+            _dBFilePath = DBFilePath;
         }
 
         [GlobalSetup]
@@ -37,7 +35,7 @@ namespace IP2Region.Test.Benchmark
         [GlobalCleanup]
         public void Dispose()
         {
-            _search?.Dispose();
+            _search.Dispose();
         }
 
         public String GetRandomIP()

--- a/binding/c#/IP2Region.Test.xUnit/SearchTest.cs
+++ b/binding/c#/IP2Region.Test.xUnit/SearchTest.cs
@@ -4,9 +4,10 @@ using Xunit;
 
 namespace IP2Region.Test.xUnit
 {
-    public class SearchTest
+    public class SearchTest : IDisposable
     {
         private readonly DbSearcher _search;
+        
         public SearchTest()
         {
             _search = new DbSearcher(Environment.CurrentDirectory + @"\DB\ip2region.db");
@@ -41,6 +42,9 @@ namespace IP2Region.Test.xUnit
             Assert.Equal(bTreeSearchResult.Region, memResult.Region);
         }
 
-
+        public void Dispose()
+        {
+            _search.Dispose();
+        }
     }
 }

--- a/binding/c#/IP2Region_NetFx_Test/Program.cs
+++ b/binding/c#/IP2Region_NetFx_Test/Program.cs
@@ -1,9 +1,5 @@
 ﻿using IP2Region;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace IP2Region_NetFx_Test
 {
@@ -11,9 +7,11 @@ namespace IP2Region_NetFx_Test
     {
         static void Main(string[] args)
         {
-            DbSearcher _search = new DbSearcher(Environment.CurrentDirectory + @"\DB\ip2region.db");
-            Console.WriteLine(_search.MemorySearch("183.192.62.65").Region);
-            Console.Read();
+            using (var _search = new DbSearcher(Environment.CurrentDirectory + @"\DB\ip2region.db"))
+            {
+                Console.WriteLine(_search.MemorySearch("183.192.62.65").Region);
+                Console.Read();
+            }
         }
     }
 }

--- a/binding/c#/IP2Region_NetFx_Test/Properties/AssemblyInfo.cs
+++ b/binding/c#/IP2Region_NetFx_Test/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // 有关程序集的一般信息由以下


### PR DESCRIPTION
`_search` should release resouces because the file state is still open. RocherKong's missing of that.