### PR TITLE
[Fix] Fix csharp formations

### DIFF
--- a/binding/c#/IP2Region.Test.Benchmark/DbSearch_Test.cs
+++ b/binding/c#/IP2Region.Test.Benchmark/DbSearch_Test.cs
@@ -13,7 +13,6 @@ namespace IP2Region.Test.Benchmark
         public DataBlock MemorySearch()
         {
             RandomIP = GetRandomIP();
-            //Console.WriteLine(RandomIP);
             return _search.MemorySearch(RandomIP);
         }
 

--- a/binding/c#/IP2Region.Test.Benchmark/Program.cs
+++ b/binding/c#/IP2Region.Test.Benchmark/Program.cs
@@ -7,7 +7,7 @@ namespace IP2Region.Test.Benchmark
     {
         static void Main(string[] args)
         {
-            Console.WriteLine("Welcome To IP2Regin!");
+            Console.WriteLine("Now starting benchmark test, please wait......");
             var summary = BenchmarkRunner.Run<DbSearch_Test>();
             Console.ReadLine();
         }

--- a/binding/c#/IP2Region.Test.xUnit/SearchTest.cs
+++ b/binding/c#/IP2Region.Test.xUnit/SearchTest.cs
@@ -30,9 +30,10 @@ namespace IP2Region.Test.xUnit
         [Fact]
         public async Task SearchAsync_Test()
         {
-            var memResult = await _search.MemorySearchAsync("183.192.62.65");
-            var binarySearchResult = await _search.BinarySearchAsync("183.192.62.65");
-            var bTreeSearchResult = await _search.BtreeSearchAsync("183.192.62.65");
+            // We don't need the synchronizeContext, so just set to false
+            var memResult = await _search.MemorySearchAsync("183.192.62.65").ConfigureAwait(false);
+            var binarySearchResult = await _search.BinarySearchAsync("183.192.62.65").ConfigureAwait(false);
+            var bTreeSearchResult = await _search.BtreeSearchAsync("183.192.62.65").ConfigureAwait(false);
 
             Assert.NotNull(memResult.Region);
             Assert.NotNull(binarySearchResult.Region);

--- a/binding/c#/README.md
+++ b/binding/c#/README.md
@@ -1,22 +1,30 @@
 # IP2Region C# Client
 
 ## How To Use
-### 1.Install from Nuget. Support .Net Framework 4.5+ And netstandard 2.0(.net core)
+### 1.Install from Nuget. Support .Net Framework (>=4.5) And netstandard 2.0(.net core)
 ```powershell
 Install-Package IP2Region
 ```
-### 2.Init DbSearcher with Newest DBFile Downloaded into your project.(https://github.com/lionsoul2014/ip2region/blob/master/data/ip2region.db)
-```c#
-DbSearcher _search=new DbSearcher(Environment.CurrentDirectory + @"\DB\ip2region.db");
-```
-### 3.Invoke Search Method.(MemorySearch,BtreeSearch,BinarySearch)
-```c#
+### 2.Init DbSearcher with [the newest DBFile](https://github.com/lionsoul2014/ip2region/blob/master/data/ip2region.db) Downloaded into your project, and invoke your search methods as below:
+```csharp
+using (var _search = new DbSearcher(Environment.CurrentDirectory + @"\DB\ip2region.db"))
+{
     _search.MemorySearch("183.192.62.65").Region;
-    _search.MemorySearchAsync("183.192.62.65").Result.Region;
     _search.BinarySearch("183.192.62.65").Region;
-    _search.BinarySearchAsync("183.192.62.65").Result.Region;
     _search.BtreeSearch("183.192.62.65").Region;
-    _search.BtreeSearchAsync("183.192.62.65").Result.Region;
+}
+```
+For async methods (Methods with the suffix "Async"), just put them with `async` and `await`.
+If you don't need the `SynchronizedContext`, please use `ConfigureAwait(false)`.
+For more about this, please read https://msdn.microsoft.com/en-us/magazine/jj991977.aspx.
+
+```csharp
+ public async Task SearchAsync_Test()
+        {
+            // We don't need the synchronizeContext, so just set to false. 
+            // So as for BinarySearchAsync and BtreeSearchAsync
+            var memResult = await _search.MemorySearchAsync("183.192.62.65").ConfigureAwait(false);
+        }
 ```
 
 ## Test Result(From /IP2Region.Test.Benchmark)
@@ -28,11 +36,3 @@ BinarySearch | 52.22 us | 0.6403 us | 0.5347 us |    5 |
 BinarySearch_Async | 53.03 us | 1.0271 us | 0.9608 us |    6 |
 BtreeSearch | 19.05 us | 0.2464 us | 0.2305 us |    3 |
 BtreeSearch_Async | 19.40 us | 0.3820 us | 0.6690 us |    4 |
-
-## Contribute History
-| Name | Github | Responsibility | Date | Remark |
-| ------ | ------ | ------ | ------ | ------ |
-| RocherKong | https://github.com/RocherKong | Creator | 20180209|
-| Dongwei | https://github.com/Maledong | Contributor | 20180708 | 1.Async 2.NetFxBenchmark 3.Rename of some Methods
-| RocherKong | https://github.com/RocherKong | Creator | 20180209| 1.CodeStandardized 2.Support Netfx4.5 3.TestStandardized
-


### PR DESCRIPTION
1) In `README.md`, we shouldn't use `c#` but `csharp` to make md recoginize it's the C# formation of codes.

2) Add 'ConfigureAwait(false)' as for the MSDN magazine usage.

3) Don't need Contribution History in README.md, because we can see the change logs in GitHub instead.

/cc：@lionsoul2014 @RocherKong