### PR TITLE
Add use stream method for C#

### DIFF
--- a/binding/c#/IP2Region/DBSearcher.cs
+++ b/binding/c#/IP2Region/DBSearcher.cs
@@ -23,7 +23,7 @@ namespace IP2Region
         /// <summary>
         /// db file access handler
         /// </summary>
-        private FileStream _raf = null;
+        private Stream _raf = null;
 
         /// <summary>
         /// header blocks buffer
@@ -74,6 +74,18 @@ namespace IP2Region
         }
 
         public DbSearcher(string dbFile) : this(null, dbFile) { }
+
+        public DbSearcher(DbConfig dbConfig, Stream dbFileStream)
+        {
+            if (_dbConfig == null)
+            {
+                _dbConfig = dbConfig;
+            }
+
+            _raf = dbFileStream;
+        }
+
+        public DbSearcher(Stream dbFileStream) : this(null, dbFileStream) { }
 
         #region Sync Methods
         /// <summary>


### PR DESCRIPTION
Ip2region is a good project，I actually embed the db file into the assembly in actual use. when I read the db file from the assembly, it returns a stream. So I hope to add a method that uses stream.Thanks