### PR TITLE
[nodejs] publish package on npm

### DIFF
--- a/binding/nodejs/.gitignore
+++ b/binding/nodejs/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+data/

--- a/binding/nodejs/README.md
+++ b/binding/nodejs/README.md
@@ -1,5 +1,18 @@
 # nodejs 客户端
 
+## Install
+```
+npm install lionsoul-ip2region --save 
+```
+
+## Example
+
+```
+const searcher = require('lionsoul-ip2region').create();
+searcher.btreeSearchSync('xxx.xxx.xxx.xxx')
+// => { city: 2163, region: '中国|0|广东省|深圳市|联通' }
+```
+
 ## 实现情况：
 
 现已实现同步和异步查询，具体使用方法可以参考 `nodejs\tests\constructorTest.spec.js` 和`nodejs\tests\createTest.spec.js`。

--- a/binding/nodejs/deploy.sh
+++ b/binding/nodejs/deploy.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+echo 'create dir'
+if [ ! -d "data" ]; then
+  mkdir data
+fi
+
+echo "copy db"
+cp '../../data/ip2region.db' './data/'
+
+echo "npm publish"
+npm publish

--- a/binding/nodejs/ip2region.js
+++ b/binding/nodejs/ip2region.js
@@ -8,6 +8,8 @@
  * @author dongwei<maledong_github@outlook.com>
  */
 const fs = require('fs');
+const path = require('path');
+const DEFAULT_DB_PATH  = path.join(__dirname,'./data/ip2region.db') ;
 
 //#region Private Functions
 /**
@@ -134,7 +136,7 @@ class IP2Region {
     //#region Static Functions
 
     // Single Instance
-    static create(dbPath) {
+    static create(dbPath = DEFAULT_DB_PATH) {
         let existInstance = _globalInstances.get(dbPath);
         if (existInstance == null) {
             existInstance = new IP2Region({ dbPath: dbPath });

--- a/binding/nodejs/package.json
+++ b/binding/nodejs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ip2region",
+  "name": "lionsoul-ip2region",
   "version": "0.0.1",
   "description": "ip database ",
   "main": "ip2region.js",
@@ -7,6 +7,7 @@
     "test": "jest",
     "coverage": "npm run test && jest --coverage"
   },
+  "files": ["data/"],
   "repository": {
     "type": "git",
     "url": "https://github.com/lionsoul2016/ip2region"


### PR DESCRIPTION
Create a shell script to publish the package to `npm`.
Set default `dbpath` when `ip2region.create` that users do not need to know file path in the package.
Add how to use the package in `README.md`.

please run this command to publish it.
> npm login
> ./deploy.sh