### PR TITLE
fs.close不写回调函数时，在14.x及以上版本中报错

### DIFF
--- a/binding/nodejs/index.js
+++ b/binding/nodejs/index.js
@@ -122,7 +122,7 @@ class Searcher {
       }
     }
     if (fd) {
-      fs.close(fd)
+      fs.close(fd,function(){})
     }
 
     const diff = process.hrtime(startTime)
@@ -178,7 +178,7 @@ const loadVectorIndexFromFile = dbPath => {
   const fd = fs.openSync(dbPath, 'r')
   const buffer = Buffer.alloc(VectorIndexLength)
   fs.readSync(fd, buffer, 0, VectorIndexLength, 256)
-  fs.close(fd)
+  fs.close(fd,function(){})
   return buffer
 }
 
@@ -187,7 +187,7 @@ const loadContentFromFile = dbPath => {
   const buffer = Buffer.alloc(stats.size)
   const fd = fs.openSync(dbPath, 'r')
   fs.readSync(fd, buffer, 0, stats.size, 0)
-  fs.close(fd)
+  fs.close(fd,function(){})
   return buffer
 }
 


### PR DESCRIPTION
fs.close第二个参数不传入（即没有回调函数）时，在14.x及以上版本中报错Callback must be a function. Received undefined。参考：https://blog.csdn.net/qq_40875849/article/details/103712445