### PR TITLE
fix python search

### DIFF
--- a/binding/python/xdbSearcher.py
+++ b/binding/python/xdbSearcher.py
@@ -59,11 +59,11 @@ class XdbSearcher(object):
             return self.searchByIPLong(ip)
         else:
             return self.searchByIPLong(ip)
-       
+
     def searchByIPStr(self, ip):
         if not ip.isdigit(): ip = self.ip2long(ip)
         return self.searchByIPLong(ip)
-         
+
     def searchByIPLong(self, ip):
         # locate the segment index block based on the vector index
         sPtr = ePtr = 0
@@ -162,7 +162,7 @@ class XdbSearcher(object):
         return 0
 
     def getInt2(self, b, offset):
-        return ((b[offset] & 0x000000FF) | (b[offset+1] & 0x0000FF00))
+        return ((b[offset] & 0x000000FF) | (b[offset+1] << 8))
 
     def close(self):
         if self.__f is not None:
@@ -179,10 +179,10 @@ if __name__ == '__main__':
     # 1. 缓存
     dbPath = "./data/ip2region.xdb";
     cb = XdbSearcher.loadContentFromFile(dbfile=dbPath)
-    
+
     # 2. 创建查询对象
     searcher = XdbSearcher(contentBuff=cb)
-    
+
     # 3. 执行查询
     # ip = "1.2.3.4"
     for ip in ip_array:


### PR DESCRIPTION
## 问题出处
https://gitee.com/lionsoul/ip2region/issues/I66E2T

> python版的检索getInt2方法取两个字节有问题

## 复现问题
### 1. 构建一个大的地址信息, 并生成对应的 xdb 文件
```
$ cd maker/cpp
$ cat 1.txt 

1.1.1.1|1.1.1.1|测试开始1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111测试完成

$ make
g++ -std=c++11 -O2 xdb_make.cc xdb_make_test.cc -o xdb_make
g++ -std=c++11 -O2 xdb_edit.cc xdb_edit_test.cc -o xdb_edit
$ ./xdb_edit --old ../../data/ip.merge.txt --new 1.txt 
took: 2.32s
$ ./xdb_make --db ../../data/ip2region.xdb --src ../../data/ip.merge.txt 
took: 1.56s
```

## 2. 使用 python-search 测试
```
$ cd ../../binding/python/
$ python3 ./search_test.py --db ../../data/ip2region.xdb --cache-policy content
ip2region xdb searcher test program, cachePolicy: content
type 'quit' to exit
ip2region>> 1.1.1.1
{region: 测试开始111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111 , took: 0.2584 ms}
ip2region>> 
```

发现显示的地址信息不全, 即 取地址信息长度的时候, 没有取高 8 位

## 解决问题
见 PR

## 再次测试
```
$ python3 ./search_test.py --db ../../data/ip2region.xdb --cache-policy content
ip2region xdb searcher test program, cachePolicy: content
type 'quit' to exit
ip2region>> 1.1.1.1
{region: 测试开始1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111测试完成 , took: 0.159 ms}
```

地址信息完整了
