### PR TITLE
fix Index overflow for the cidr parse with bits equals to IP max bits

### DIFF
--- a/maker/golang/xdb/util.go
+++ b/maker/golang/xdb/util.go
@@ -65,7 +65,14 @@ func CIDR2Range(cidrStr string) ([]byte, []byte, error) {
 
 	// border byte rest bit filled with 1
 	byteIdx := bits / 8
-	eip[byteIdx] |= bitMaskList[bits-(byteIdx*8)]
+
+	// check and fill the border byte bits.
+	// @Note this check is possible since there will be bits
+	// like 32 in IPv4 and 128 in IPv6.
+	// fmt.Printf("%s -> bits=%d, byteIdx=%d, maskIdx=%d\n", cidrStr, bits, byteIdx, bits-byteIdx*8)
+	if byteIdx < ipl {
+		eip[byteIdx] |= bitMaskList[bits-(byteIdx*8)]
+	}
 
 	// fill all the rest bits with 1
 	for bi := byteIdx + 1; bi < ipl; bi++ {

--- a/maker/golang/xdb/util_test.go
+++ b/maker/golang/xdb/util_test.go
@@ -364,3 +364,19 @@ func TestCIDR2Range(t *testing.T) {
 		fmt.Printf("cidr=%s: {sip=%s, eip=%s}\n", item[0], item[1], item[2])
 	}
 }
+
+func TestCIDR2Range_Fix(t *testing.T) {
+	var strList = []string{
+		// "14.200.21.0/24",
+		"14.200.21.158/32",
+	}
+
+	for _, cidr := range strList {
+		sip, eip, err := CIDR2Range(cidr)
+		if err != nil {
+			t.Fatalf("CIDR2Range: %s", err)
+		}
+
+		fmt.Printf("cidr=%s: {sip=%s, eip=%s}\n", cidr, IP2String(sip), IP2String(eip))
+	}
+}


### PR DESCRIPTION
fix the bits fill with situations like:
```
14.200.21.158/32
```