### PR TITLE
Fix Python test helpers to use function arguments

### DIFF
--- a/binding/python/bench_test.py
+++ b/binding/python/bench_test.py
@@ -49,7 +49,7 @@ def run_bench_test(db_path: str, src_path: str, cache_policy: str):
     # create the searcher
     searcher = None
     try:
-        searcher = create_searcher(args.db, args.cache_policy)
+        searcher = create_searcher(db_path, cache_policy)
     except Exception as e:
         print("failed to create searcher: {}".format(str(e)))
         return

--- a/binding/python/search_test.py
+++ b/binding/python/search_test.py
@@ -49,7 +49,7 @@ def run_search_test(db_path: str, cache_policy: str):
     # create the searcher
     searcher = None
     try:
-        searcher = create_searcher(args.db, args.cache_policy)
+        searcher = create_searcher(db_path, cache_policy)
     except Exception as e:
         print("failed to create searcher: {}".format(str(e)))
         return


### PR DESCRIPTION
This fixes the Python search and bench test helpers so they use the `db_path` and `cache_policy` values passed into the function instead of reading the global CLI `args` object.

The command-line behavior remains unchanged, but the functions now behave correctly when called directly from tests or other scripts.

Validation:
- `python -m py_compile binding/python/search_test.py binding/python/bench_test.py`