### PR TITLE
fix: correct license metadata and Python packaging typo

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,11 @@
+ip2region is dual-licensed under the Apache License 2.0 and the MIT License.
+
+You may use, distribute, and modify this software under either license,
+at your option. The full text of both licenses appears below.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+
+==============================================================================
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/binding/javascript/package.json
+++ b/binding/javascript/package.json
@@ -31,11 +31,20 @@
     "ipv6-search"
   ],
   "author": "lionsoul2014",
-  "license": "ISC",
+  "license": "Apache-2.0 OR MIT",
   "bugs": {
     "url": "https://github.com/lionsoul2014/ip2region/issues"
   },
   "homepage": "https://github.com/lionsoul2014/ip2region#readme",
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "searcher.js",
+    "util.js",
+    "README.md",
+    "README_zh.md",
+    "LICENSE.md"
+  ],
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "argparse": "^2.0.1",

--- a/binding/python/MANIFEST.in
+++ b/binding/python/MANIFEST.in
@@ -1,5 +1,5 @@
-﻿include LICENSE
-include ReadMe.md
+include LICENSE
+include README.md
 include search_test.py
 include bench_test.py
 recursive-include tests


### PR DESCRIPTION
## 背景

JS binding 的 `package.json` 中错误地声明为 `ISC`，导致 npm 错误将 `ip2region.js` 识别为 ISC license，与项目实际协议不符。

## 改动

- `LICENSE.md`
  在文件顶部补充 `SPDX-License-Identifier: Apache-2.0 OR MIT`，方便自动化工具正确识别协议

- `binding/javascript/package.json`
  修正 `license` 字段为 `Apache-2.0 OR MIT`
  新增 `files` 字段，满足 `npm pack` 的最佳实践。

- `binding/python/MANIFEST.in`
  修正 `ReadMe.md` 为 `README.md`，修复 Python 打包漏掉 README 的问题

## 兼容性

无破坏性变更。

## 关联

Closes #493
Closes #494
