### PR TITLE
Fix golang searcher

### DIFF
--- a/binding/golang/service/config.go
+++ b/binding/golang/service/config.go
@@ -70,6 +70,7 @@ func newConfig(cachePolicy int, ipVersion *xdb.Version, xdbPath string, searcher
 	if err != nil {
 		return nil, err
 	}
+	defer handle.Close()
 
 	// 1, verify the xdb
 	err = xdb.Verify(handle)

--- a/binding/golang/xdb/header.go
+++ b/binding/golang/xdb/header.go
@@ -61,7 +61,7 @@ type Header struct {
 }
 
 func NewHeader(input []byte) (*Header, error) {
-	if len(input) < 16 {
+	if len(input) < 20 {
 		return nil, fmt.Errorf("invalid input buffer")
 	}
 


### PR DESCRIPTION
1, close the handle.
2, extend the check length for runtime ptr size.