### PR TITLE
fix：避免在 32 位平台上出现 maxFilePtr 溢出

### DIFF
--- a/binding/golang/xdb/util.go
+++ b/binding/golang/xdb/util.go
@@ -165,7 +165,7 @@ func Verify(handle *os.File) error {
 		return fmt.Errorf("file stat: %w", err)
 	}
 
-	maxFilePtr := int64(1<<(runtimePtrBytes*8) - 1)
+	maxFilePtr := int64(1)<<(runtimePtrBytes*8) - 1
 	if stat.Size() > maxFilePtr {
 		return fmt.Errorf("xdb file exceeds the maximum supported bytes: %d", maxFilePtr)
 	}


### PR DESCRIPTION
1 是 int，32 位平台上 1<<32 == 0，导致 maxFilePtr == -1，任何 xdb 文件都会报 "exceeds the maximum supported bytes"。但是在 大部分人用的 amd64 环境不触发，是平台相关 bug。应改为 `int64(1) << (runtimePtrBytes*8) - 1`。