### PR TITLE
fix: `IPv4.IPCompare` 会修改输入切片（就地反转字节序）

### DIFF
--- a/binding/golang/xdb/version.go
+++ b/binding/golang/xdb/version.go
@@ -42,9 +42,15 @@ var (
 		IPCompare: func(ip1, ip2 []byte) int {
 			// ip1 - with Big endian byte order parsed from an input
 			// ip2 - with Little endian byte order read from the xdb index
-			ip2[0], ip2[3] = ip2[3], ip2[0]
-			ip2[1], ip2[2] = ip2[2], ip2[1]
-			return bytes.Compare(ip1, ip2)
+			// compare from the tail of ip2 to avoid mutating the input buffer
+			for i, j := 0, len(ip1)-1; i < len(ip1); i, j = i+1, j-1 {
+				if ip1[i] < ip2[j] {
+					return -1
+				} else if ip1[i] > ip2[j] {
+					return 1
+				}
+			}
+			return 0
 		},
 	}
 	IPv6 = &Version{

--- a/binding/golang/xdb/version_test.go
+++ b/binding/golang/xdb/version_test.go
@@ -1,0 +1,45 @@
+// Copyright 2022 The Ip2Region Authors. All rights reserved.
+// Use of this source code is governed by a Apache2.0-style
+// license that can be found in the LICENSE file.
+
+package xdb
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestIPv4IPCompareNoSideEffect(t *testing.T) {
+	// ip2 is little-endian as stored in the xdb index, it must NOT be mutated
+	ip1 := []byte{1, 2, 3, 4}
+	ip2 := []byte{4, 3, 2, 1}
+	orig := append([]byte(nil), ip2...)
+
+	if r := IPv4.IPCompare(ip1, ip2); r != 0 {
+		t.Fatalf("IPv4.IPCompare(%v, %v) = %d, 0 expected", ip1, ip2, r)
+	}
+	if !bytes.Equal(ip2, orig) {
+		t.Fatalf("IPv4.IPCompare mutated its input: got %v, want %v", ip2, orig)
+	}
+}
+
+func TestIPv4IPCompare(t *testing.T) {
+	// ip1 is big-endian, ip2 is little-endian
+	cases := []struct {
+		ip1 []byte
+		ip2 []byte
+		exp int
+	}{
+		{[]byte{1, 2, 3, 4}, []byte{4, 3, 2, 1}, 0},   // 1.2.3.4 == 1.2.3.4
+		{[]byte{1, 2, 3, 5}, []byte{4, 3, 2, 1}, 1},   // 1.2.3.5 > 1.2.3.4
+		{[]byte{1, 2, 3, 3}, []byte{4, 3, 2, 1}, -1},  // 1.2.3.3 < 1.2.3.4
+		{[]byte{58, 250, 36, 41}, []byte{41, 30, 250, 58}, 1}, // 58.250.36.41 > 58.250.30.41
+	}
+
+	for _, c := range cases {
+		r := IPv4.IPCompare(c.ip1, c.ip2)
+		if (r < 0 && c.exp >= 0) || (r == 0 && c.exp != 0) || (r > 0 && c.exp <= 0) {
+			t.Errorf("IPv4.IPCompare(%v, %v) = %d, sign %d expected", c.ip1, c.ip2, r, c.exp)
+		}
+	}
+}


### PR DESCRIPTION
- 已实测验证：b := []byte{4,3,2,1} 经调用后变成 {1,2,3,4}。
- C 版 _ipv4_sub_compare（binding/c/xdb_searcher.c:294）是从尾部倒序读取、不修改 buffer，语义相同但无副作用。当前二分查找中每次 s.read 都完整覆盖缓冲所以侥幸正确，但这是"脆弱的正确"——任何外部调用者传入共享/复用切片（或未来优化复用缓冲）都会被破坏。
- 已改为从尾部倒序比较（与 C 版一致），消除副作用