### PR TITLE
fix: `SearcherPool` 关闭后 `BorrowSearcher()` 永久阻塞（死锁）

### DIFF
--- a/binding/golang/service/ip2region.go
+++ b/binding/golang/service/ip2region.go
@@ -153,6 +153,9 @@ func (ip2r *Ip2Region) v4Search(ipBytes []byte) (string, error) {
 	}
 
 	v4Searcher := ip2r.v4Pool.BorrowSearcher()
+	if v4Searcher == nil {
+		return "", fmt.Errorf("v4 searcher pool already closed")
+	}
 	defer ip2r.v4Pool.ReturnSearcher(v4Searcher)
 	return v4Searcher.Search(ipBytes)
 }
@@ -168,6 +171,9 @@ func (ip2r *Ip2Region) v6Search(ipBytes []byte) (string, error) {
 	}
 
 	v6Searcher := ip2r.v6Pool.BorrowSearcher()
+	if v6Searcher == nil {
+		return "", fmt.Errorf("v6 searcher pool already closed")
+	}
 	defer ip2r.v6Pool.ReturnSearcher(v6Searcher)
 	return v6Searcher.Search(ipBytes)
 }

--- a/binding/golang/service/searcher_pool.go
+++ b/binding/golang/service/searcher_pool.go
@@ -64,10 +64,15 @@ func (sp *SearcherPool) LoanCount() int {
 }
 
 func (sp *SearcherPool) BorrowSearcher() *xdb.Searcher {
-	// @Note: still accept searcher borrow while closing
-	s := <-sp.pool
-	atomic.AddInt32(&sp.loanCount, 1)
-	return s
+	// @Note: still accept searcher borrow while closing,
+	// return nil directly once the pool was closed to avoid blocking forever.
+	select {
+	case <-sp.closing:
+		return nil
+	case s := <-sp.pool:
+		atomic.AddInt32(&sp.loanCount, 1)
+		return s
+	}
 }
 
 func (sp *SearcherPool) ReturnSearcher(searcher *xdb.Searcher) {

--- a/binding/golang/service/searcher_pool_test.go
+++ b/binding/golang/service/searcher_pool_test.go
@@ -7,6 +7,7 @@ package service
 import (
 	"fmt"
 	"testing"
+	"time"
 )
 
 func TestV4SearcherPool(t *testing.T) {
@@ -67,4 +68,33 @@ func TestV6SearcherPool(t *testing.T) {
 
 	// close the searcher pool
 	searcherPool.Close()
+}
+
+func TestBorrowAfterClose(t *testing.T) {
+	v4Config, err := NewV4Config(VIndexCache, "../../../data/ip2region_v4.xdb", 2)
+	if err != nil {
+		t.Fatalf("failed to new v4 config: %s", err)
+	}
+
+	searcherPool, err := NewSearcherPool(v4Config)
+	if err != nil {
+		t.Fatalf("failed to create searcher pool: %s", err)
+	}
+
+	searcherPool.Close()
+
+	// borrowing after close should return nil immediately instead of blocking forever
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if s := searcherPool.BorrowSearcher(); s != nil {
+			t.Errorf("BorrowSearcher after close: %v returned, nil expected", s)
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("BorrowSearcher after close blocked forever")
+	}
 }


### PR DESCRIPTION
CloseTimeout 会 close(sp.closing) 并清空池中所有 searcher，但 pool 通道本身从不关闭。任何在 `ip2region.Close()` 之后继续调用 `Search()` 的代码会永久挂起。README 只提到"池空时等待"，未提关闭后不可再查询。

池关闭后 BorrowSearcher 返回 nil（不再永久阻塞），v4Search/v6Search 增加 nil 检查