### PR TITLE
fix: 修复`LoadHeaderFromBuff` 无长度检查，可能 panic的问题

### DIFF
--- a/binding/golang/xdb/util.go
+++ b/binding/golang/xdb/util.go
@@ -222,6 +222,10 @@ func LoadHeaderFromFile(dbFile string) (*Header, error) {
 
 // LoadHeaderFromBuff wrap the header info from the content buffer
 func LoadHeaderFromBuff(cBuff []byte) (*Header, error) {
+	if len(cBuff) < HeaderInfoLength {
+		return nil, fmt.Errorf("invalid content buffer: %d bytes, %d expected", len(cBuff), HeaderInfoLength)
+	}
+
 	return NewHeader(cBuff[0:HeaderInfoLength])
 }
 

--- a/binding/golang/xdb/util_test.go
+++ b/binding/golang/xdb/util_test.go
@@ -173,3 +173,18 @@ func TestLoadHeader(t *testing.T) {
 	fmt.Printf("IPVersion       : %d\n", header.IPVersion)
 	fmt.Printf("RuntimePtrBytes : %d\n", header.RuntimePtrBytes)
 }
+
+func TestLoadHeaderFromBuffShortBuffer(t *testing.T) {
+	// a short buffer should return an error instead of panicking on slice out of range
+	if _, err := LoadHeaderFromBuff(make([]byte, HeaderInfoLength-1)); err == nil {
+		t.Fatal("LoadHeaderFromBuff with short buffer: error expected")
+	}
+
+	header, err := LoadHeaderFromBuff(make([]byte, HeaderInfoLength))
+	if err != nil {
+		t.Fatalf("LoadHeaderFromBuff with full buffer: %s", err)
+	}
+	if header == nil {
+		t.Fatal("LoadHeaderFromBuff returned a nil header")
+	}
+}


### PR DESCRIPTION
LoadHeaderFromBuff 增加长度检查，避免短缓冲区panic