### PR TITLE
fix: 修复`CloseTimeout` 每次循环迭代都新建 `time.After(d)` timer 的问题

### DIFF
--- a/binding/golang/service/searcher_pool.go
+++ b/binding/golang/service/searcher_pool.go
@@ -91,12 +91,18 @@ func (sp *SearcherPool) Close() {
 
 func (sp *SearcherPool) CloseTimeout(d time.Duration) {
 	close(sp.closing)
+
+	// use a single timer for the whole closing progress
+	// so the max wait duration is bounded by d instead of d * pool size.
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
 	for {
 		timeout := false
 		select {
 		case s := <-sp.pool:
 			s.Close()
-		case <-time.After(d):
+		case <-timer.C:
 			// check if all the loaned searchers was closed
 			timeout = true
 		}

--- a/binding/golang/service/searcher_pool_test.go
+++ b/binding/golang/service/searcher_pool_test.go
@@ -7,6 +7,7 @@ package service
 import (
 	"fmt"
 	"testing"
+	"time"
 )
 
 func TestV4SearcherPool(t *testing.T) {
@@ -67,4 +68,32 @@ func TestV6SearcherPool(t *testing.T) {
 
 	// close the searcher pool
 	searcherPool.Close()
+}
+
+func TestCloseTimeoutBounded(t *testing.T) {
+	v4Config, err := NewV4Config(VIndexCache, "../../../data/ip2region_v4.xdb", 2)
+	if err != nil {
+		t.Fatalf("failed to new v4 config: %s", err)
+	}
+
+	searcherPool, err := NewSearcherPool(v4Config)
+	if err != nil {
+		t.Fatalf("failed to create searcher pool: %s", err)
+	}
+
+	// borrow one searcher and never return it,
+	// CloseTimeout should return roughly after the given duration
+	s := searcherPool.BorrowSearcher()
+	defer s.Close()
+
+	start := time.Now()
+	searcherPool.CloseTimeout(200 * time.Millisecond)
+	elapsed := time.Since(start)
+
+	if elapsed < 200*time.Millisecond {
+		t.Fatalf("CloseTimeout returned too early: %s", elapsed)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("CloseTimeout took too long: %s", elapsed)
+	}
 }


### PR DESCRIPTION
CloseTimeout 改用单个 time.NewTimer，整体等待时间有界（不再 N×d