### PR TITLE
fix: 将语义误导的 IPSub 函数重命名为 IPAdd

### DIFF
--- a/binding/golang/xdb/util.go
+++ b/binding/golang/xdb/util.go
@@ -82,8 +82,10 @@ func IPSubOne(ip []byte) []byte {
 	return r
 }
 
-// IPSub Sub the spcecified two byte ip
-func IPSub(sip, eip []byte) ([]byte, error) {
+// IPAdd Add the specified two byte ips.
+// @Note: the implementation adds the two ips, which is the sum of them,
+// the original misleading name IPSub was renamed to IPAdd.
+func IPAdd(sip, eip []byte) ([]byte, error) {
 	if len(sip) != len(eip) {
 		return []byte{}, fmt.Errorf("length of the two ips are not the same")
 	}
@@ -104,6 +106,13 @@ func IPSub(sip, eip []byte) ([]byte, error) {
 	} else {
 		return result[1:], nil
 	}
+}
+
+// IPSub is deprecated, use IPAdd instead.
+// The old implementation actually adds the two ips,
+// so it was renamed to IPAdd to reflect the real behavior.
+func IPSub(sip, eip []byte) ([]byte, error) {
+	return IPAdd(sip, eip)
 }
 
 // IPHalf get the half value of an input byte ip
@@ -127,9 +136,9 @@ func IPHalf(ip []byte) []byte {
 
 // IPMiddle get the middle value of two input ip address
 func IPMiddle(sip, eip []byte) ([]byte, error) {
-	buf, err := IPSub(sip, eip)
+	buf, err := IPAdd(sip, eip)
 	if err != nil {
-		return []byte{}, fmt.Errorf("IPSub(%s, %s): %w", IP2String(sip), IP2String(eip), err)
+		return []byte{}, fmt.Errorf("IPAdd(%s, %s): %w", IP2String(sip), IP2String(eip), err)
 	}
 
 	return IPHalf(buf), nil

--- a/binding/golang/xdb/util_test.go
+++ b/binding/golang/xdb/util_test.go
@@ -9,6 +9,7 @@
 package xdb
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"testing"
@@ -42,29 +43,29 @@ func TestIPCompare(t *testing.T) {
 	}
 }
 
-func TestIPSub(t *testing.T) {
-	var strToSub = "1.2.3.4"
-	bytesToSub, err := ParseIP(strToSub)
+func TestIPAdd(t *testing.T) {
+	var strToAdd = "1.2.3.4"
+	bytesToAdd, err := ParseIP(strToAdd)
 	if err != nil {
-		t.Fatalf("failed to parse ip %s", strToSub)
+		t.Fatalf("failed to parse ip %s", strToAdd)
 	}
-	var intToSub = int(binary.BigEndian.Uint32(bytesToSub))
-	t.Logf("to sub ip: %d -> %s", intToSub, strToSub)
+	var intToAdd = int(binary.BigEndian.Uint32(bytesToAdd))
+	t.Logf("to add ip: %d -> %s", intToAdd, strToAdd)
 
 	counter := 0
 	buf := make([]byte, 4)
 	for i := 0; i < 0x2FFFFFFF; i++ {
 		binary.BigEndian.PutUint32(buf, uint32(i))
-		subVal, err := IPSub(buf, bytesToSub)
+		addVal, err := IPAdd(buf, bytesToAdd)
 		if err != nil {
-			t.Fatalf("failed to IPSub(%s,%s): %s", IP2String(buf), strToSub, err)
+			t.Fatalf("failed to IPAdd(%s,%s): %s", IP2String(buf), strToAdd, err)
 		}
 
 		// do it as two integers
-		byteSub := int(binary.BigEndian.Uint32(subVal))
-		intSub := i + intToSub
-		if byteSub != intSub {
-			t.Fatal("byte and int sub value are not the same")
+		byteAdd := int(binary.BigEndian.Uint32(addVal))
+		intAdd := i + intToAdd
+		if byteAdd != intAdd {
+			t.Fatal("byte and int add value are not the same")
 		}
 
 		counter++
@@ -88,7 +89,7 @@ func TestIPHalf(t *testing.T) {
 	}
 }
 
-func TestSubOverflow(t *testing.T) {
+func TestAddOverflow(t *testing.T) {
 	var ip1Str = "255.255.255.250"
 	ip1Bytes, err := ParseIP(ip1Str)
 	if err != nil {
@@ -98,12 +99,32 @@ func TestSubOverflow(t *testing.T) {
 	var buff = make([]byte, 4)
 	for i := 0; i < 10; i++ {
 		binary.BigEndian.PutUint32(buff, uint32(i))
-		ipSub, err := IPSub(ip1Bytes, buff)
+		ipAdd, err := IPAdd(ip1Bytes, buff)
 		if err != nil {
-			t.Fatalf("failed to IPSub(%s, %s): %s", ip1Str, IP2String(buff), err)
+			t.Fatalf("failed to IPAdd(%s, %s): %s", ip1Str, IP2String(buff), err)
 		}
 
-		t.Logf("IPSub(%s, %s) = %+v", ip1Str, IP2String(buff), ipSub)
+		t.Logf("IPAdd(%s, %s) = %+v", ip1Str, IP2String(buff), ipAdd)
+	}
+}
+
+// TestIPSubCompat verifies the deprecated IPSub alias keeps working
+func TestIPSubCompat(t *testing.T) {
+	sip := []byte{1, 2, 3, 4}
+	eip := []byte{4, 3, 2, 1}
+
+	sub, err := IPSub(sip, eip)
+	if err != nil {
+		t.Fatalf("failed to IPSub(%s, %s): %s", IP2String(sip), IP2String(eip), err)
+	}
+
+	add, err := IPAdd(sip, eip)
+	if err != nil {
+		t.Fatalf("failed to IPAdd(%s, %s): %s", IP2String(sip), IP2String(eip), err)
+	}
+
+	if !bytes.Equal(sub, add) {
+		t.Fatalf("IPSub and IPAdd should be the same, got %v vs %v", sub, add)
 	}
 }
 

--- a/maker/golang/xdb/util.go
+++ b/maker/golang/xdb/util.go
@@ -134,8 +134,10 @@ func IPSubOne(ip []byte) []byte {
 	return r
 }
 
-// IPSub Sub the spcecified two byte ip
-func IPSub(sip, eip []byte) ([]byte, error) {
+// IPAdd Add the specified two byte ips.
+// @Note: the implementation adds the two ips, which is the sum of them,
+// the original misleading name IPSub was renamed to IPAdd.
+func IPAdd(sip, eip []byte) ([]byte, error) {
 	if len(sip) != len(eip) {
 		return []byte{}, fmt.Errorf("length of the two ips are not the same")
 	}
@@ -179,9 +181,9 @@ func IPHalf(ip []byte) []byte {
 
 // IPMiddle get the middle value of two input ip address
 func IPMiddle(sip, eip []byte) ([]byte, error) {
-	buf, err := IPSub(sip, eip)
+	buf, err := IPAdd(sip, eip)
 	if err != nil {
-		return []byte{}, fmt.Errorf("IPSub(%s, %s): %w", IP2String(sip), IP2String(eip), err)
+		return []byte{}, fmt.Errorf("IPAdd(%s, %s): %w", IP2String(sip), IP2String(eip), err)
 	}
 
 	return IPHalf(buf), nil

--- a/maker/golang/xdb/util_test.go
+++ b/maker/golang/xdb/util_test.go
@@ -101,29 +101,29 @@ func TestIPSubOne2(t *testing.T) {
 	fmt.Printf("nip: %+v, ip:%+v", ip, nip)
 }
 
-func TestIPSub(t *testing.T) {
-	var strToSub = "1.2.3.4"
-	bytesToSub, err := ParseIP(strToSub)
+func TestIPAdd(t *testing.T) {
+	var strToAdd = "1.2.3.4"
+	bytesToAdd, err := ParseIP(strToAdd)
 	if err != nil {
-		t.Fatalf("failed to parse ip %s", strToSub)
+		t.Fatalf("failed to parse ip %s", strToAdd)
 	}
-	var intToSub = int(binary.BigEndian.Uint32(bytesToSub))
-	t.Logf("to sub ip: %d -> %s", intToSub, strToSub)
+	var intToAdd = int(binary.BigEndian.Uint32(bytesToAdd))
+	t.Logf("to add ip: %d -> %s", intToAdd, strToAdd)
 
 	counter := 0
 	buf := make([]byte, 4)
 	for i := 0; i < 0x2FFFFFFF; i++ {
 		binary.BigEndian.PutUint32(buf, uint32(i))
-		subVal, err := IPSub(buf, bytesToSub)
+		addVal, err := IPAdd(buf, bytesToAdd)
 		if err != nil {
-			t.Fatalf("failed to IPSub(%s,%s): %s", IP2String(buf), strToSub, err)
+			t.Fatalf("failed to IPAdd(%s,%s): %s", IP2String(buf), strToAdd, err)
 		}
 
 		// do it as two integers
-		byteSub := int(binary.BigEndian.Uint32(subVal))
-		intSub := i + intToSub
-		if byteSub != intSub {
-			t.Fatal("byte and int sub value are not the same")
+		byteAdd := int(binary.BigEndian.Uint32(addVal))
+		intAdd := i + intToAdd
+		if byteAdd != intAdd {
+			t.Fatal("byte and int add value are not the same")
 		}
 
 		counter++
@@ -147,7 +147,7 @@ func TestIPHalf(t *testing.T) {
 	}
 }
 
-func TestSubOverflow(t *testing.T) {
+func TestAddOverflow(t *testing.T) {
 	var ip1Str = "255.255.255.250"
 	ip1Bytes, err := ParseIP(ip1Str)
 	if err != nil {
@@ -157,12 +157,12 @@ func TestSubOverflow(t *testing.T) {
 	var buff = make([]byte, 4)
 	for i := 0; i < 10; i++ {
 		binary.BigEndian.PutUint32(buff, uint32(i))
-		ipSub, err := IPSub(ip1Bytes, buff)
+		ipAdd, err := IPAdd(ip1Bytes, buff)
 		if err != nil {
-			t.Fatalf("failed to IPSub(%s, %s): %s", ip1Str, IP2String(buff), err)
+			t.Fatalf("failed to IPAdd(%s, %s): %s", ip1Str, IP2String(buff), err)
 		}
 
-		t.Logf("IPSub(%s, %s) = %+v", ip1Str, IP2String(buff), ipSub)
+		t.Logf("IPAdd(%s, %s) = %+v", ip1Str, IP2String(buff), ipAdd)
 	}
 }
 


### PR DESCRIPTION
binding/golang/xdb/util.go 中的 IPSub(sip, eip []byte) 函数名和注释均为 "Sub"（减法），但实际实现是加法（逐字节求和并进位），其唯一用途是配合 IPHalf 计算两个 IP 的中间值 IPMiddle = (sip + eip) >> 1，现有测试也验证的是加法行为。

函数名与真实行为相反，容易导致调用方误用（例如误以为能计算 IP 差值），维护成本高。maker/golang 中存在完全相同的同名函数。

改动内容

- `binding/golang/xdb/util.go`
- IPSub 重命名为 IPAdd，注释修正为加法语义说明
- 保留 IPSub 作为 deprecated 兼容别名（仅转发到 IPAdd），不破坏现有外部调用方的编译
- IPMiddle 内部改调 IPAdd，错误消息同步更新

- `binding/golang/xdb/util_test.go`
- TestIPSub → TestIPAdd、TestSubOverflow → TestAddOverflow
- 新增 TestIPSubCompat，验证 deprecated 别名行为与 IPAdd 一致

- `maker/golang/xdb/util.go` / `util_test.go`
- 同步重命名 IPSub → IPAdd（内部工具，无兼容别名负担）

> 注：IPSubOne（IP 减一）语义正确，未改动。

兼容性说明

- xdb.IPSub 保留为已弃用别名，现有用户代码无需修改即可继续编译运行
- 新代码请使用 xdb.IPAdd