### PR TITLE
fix: 修复 bench 在空源文件时除零 panic

### DIFF
--- a/binding/golang/main.go
+++ b/binding/golang/main.go
@@ -359,6 +359,16 @@ func testBench() {
 		}
 	}
 
+	if err := scanner.Err(); err != nil {
+		fmt.Printf("failed to scan source text file: %s\n", err)
+		return
+	}
+
+	if count == 0 {
+		fmt.Printf("no valid ip segment found in source file `%s`, nothing to bench\n", srcFile)
+		return
+	}
+
 	cost := time.Since(tStart)
 	fmt.Printf("Bench finished, {cachePolicy: %s, total: %d, took: %s, cost: %d μs/op}\n",
 		cachePolicy, count, cost, costs/count/1000)


### PR DESCRIPTION
### 问题描述
`ip2region bench --src=<空文件>` 会触发
`panic: runtime error: integer divide by zero`（`main.go:364` 的 `costs/count/1000` 在 `count == 0` 时除零）。

### 修复方案
- 当 `count == 0` 时打印 `no valid ip segment found ... nothing to bench`
  并提前返回；
- 顺带检查 `scanner.Err()`，扫描失败时给出错误提示，避免静默产出错误结果。

### 验证
- 空源文件：输出友好提示，不再 panic；
- 正常源文件：bench 正常执行，输出 `cost: 6 μs/op`，行为与修复前一致。