### PR TITLE
fix: 使 SearcherPool 的关闭操作幂等，避免重复 Close 时 panic

### DIFF
--- a/binding/golang/service/searcher_pool.go
+++ b/binding/golang/service/searcher_pool.go
@@ -6,6 +6,7 @@ package service
 
 import (
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -27,6 +28,9 @@ type SearcherPool struct {
 
 	// for pool close
 	closing chan struct{}
+
+	// make the pool close idempotent
+	closeOnce sync.Once
 
 	// searcher number that was loaned out
 	loanCount int32
@@ -95,29 +99,28 @@ func (sp *SearcherPool) Close() {
 }
 
 func (sp *SearcherPool) CloseTimeout(d time.Duration) {
-	close(sp.closing)
+	// close the pool only once, so Close/CloseTimeout could be
+	// called multiple times without panicking on a closed channel.
+	sp.closeOnce.Do(func() {
+		close(sp.closing)
+	})
 
 	// wait timeout
 	timer := time.NewTimer(d)
 	defer timer.Stop()
 
 	for {
-		timeout := false
-		select {
-		case s := <-sp.pool:
-			s.Close()
-		case <-timer.C:
-			// check if all the loaned searchers was closed
-			timeout = true
-		}
-
+		// all the searchers are closed already, done.
 		lc, left := sp.LoanCount(), len(sp.pool)
 		if left == 0 && lc == 0 {
 			break
 		}
 
-		if timeout {
-			break
+		select {
+		case s := <-sp.pool:
+			s.Close()
+		case <-timer.C:
+			return
 		}
 	}
 }

--- a/binding/golang/service/searcher_pool_test.go
+++ b/binding/golang/service/searcher_pool_test.go
@@ -98,3 +98,50 @@ func TestBorrowAfterClose(t *testing.T) {
 		t.Fatal("BorrowSearcher after close blocked forever")
 	}
 }
+
+func TestCloseIdempotent(t *testing.T) {
+	v4Config, err := NewV4Config(VIndexCache, "../../../data/ip2region_v4.xdb", 2)
+	if err != nil {
+		t.Fatalf("failed to new v4 config: %s", err)
+	}
+
+	searcherPool, err := NewSearcherPool(v4Config)
+	if err != nil {
+		t.Fatalf("failed to create searcher pool: %s", err)
+	}
+
+	// closing the pool multiple times must not panic
+	// (regression: close of closed channel)
+	searcherPool.Close()
+	searcherPool.Close()
+	searcherPool.CloseTimeout(time.Second)
+}
+
+func TestCloseIdempotentConcurrent(t *testing.T) {
+	v4Config, err := NewV4Config(VIndexCache, "../../../data/ip2region_v4.xdb", 3)
+	if err != nil {
+		t.Fatalf("failed to new v4 config: %s", err)
+	}
+
+	searcherPool, err := NewSearcherPool(v4Config)
+	if err != nil {
+		t.Fatalf("failed to create searcher pool: %s", err)
+	}
+
+	// concurrent closes must also be safe with sync.Once
+	done := make(chan struct{})
+	for i := 0; i < 8; i++ {
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("panic on concurrent close: %v", r)
+				}
+			}()
+			searcherPool.CloseTimeout(time.Second)
+			done <- struct{}{}
+		}()
+	}
+	for i := 0; i < 8; i++ {
+		<-done
+	}
+}


### PR DESCRIPTION
### 问题描述
`SearcherPool.Close()` / `CloseTimeout()` 直接执行 `close(sp.closing)`。当关闭被调用多次时——例如 `defer` 与显式 Close 叠加，或并发关闭路径会触发 `panic: close of closed channel`（重复关闭已关闭的 channel）。

### 修复方案
- 用 `sync.Once` 保护 channel 的关闭，确保只执行一次；
- 在回收循环开头增加提前退出判断：当 `len(pool) == 0 && LoanCount() == 0`
  时立即返回，重复调用无需再次回收或等待。

### 测试
- `TestCloseIdempotent`：顺序调用两次/三次 Close 不应 panic；
- `TestCloseIdempotentConcurrent`：8 个 goroutine 并发 Close 不应 panic。