### PR TITLE
fix: 为 Searcher.Search 的 buffer 读取增加边界检查，避免切片越界 panic

### DIFF
--- a/binding/golang/xdb/searcher.go
+++ b/binding/golang/xdb/searcher.go
@@ -136,9 +136,15 @@ func (s *Searcher) Search(ip any) (string, error) {
 	var idx = il0*VectorIndexCols*VectorIndexSize + il1*VectorIndexSize
 	var sPtr, ePtr = uint32(0), uint32(0)
 	if s.vectorIndex != nil {
+		if len(s.vectorIndex) < idx+VectorIndexSize {
+			return "", fmt.Errorf("vector index buffer too short: %d bytes, %d expected", len(s.vectorIndex), idx+VectorIndexSize)
+		}
 		sPtr = binary.LittleEndian.Uint32(s.vectorIndex[idx:])
 		ePtr = binary.LittleEndian.Uint32(s.vectorIndex[idx+4:])
 	} else if s.contentBuff != nil {
+		if len(s.contentBuff) < HeaderInfoLength+idx+VectorIndexSize {
+			return "", fmt.Errorf("content buffer too short: %d bytes, %d expected", len(s.contentBuff), HeaderInfoLength+idx+VectorIndexSize)
+		}
 		sPtr = binary.LittleEndian.Uint32(s.contentBuff[HeaderInfoLength+idx:])
 		ePtr = binary.LittleEndian.Uint32(s.contentBuff[HeaderInfoLength+idx+4:])
 	} else {
@@ -206,6 +212,9 @@ func (s *Searcher) Search(ip any) (string, error) {
 // this operation will invoke the Seek for file based read.
 func (s *Searcher) read(offset int64, buff []byte) error {
 	if s.contentBuff != nil {
+		if offset < 0 || offset+int64(len(buff)) > int64(len(s.contentBuff)) {
+			return fmt.Errorf("content buffer out of range: read %d bytes at %d, buffer %d bytes", len(buff), offset, len(s.contentBuff))
+		}
 		cLen := copy(buff, s.contentBuff[offset:])
 		if cLen != len(buff) {
 			return fmt.Errorf("incomplete read: readed bytes should be %d", len(buff))

--- a/binding/golang/xdb/searcher_test.go
+++ b/binding/golang/xdb/searcher_test.go
@@ -1,0 +1,73 @@
+// Copyright 2022 The Ip2Region Authors. All rights reserved.
+// Use of this source code is governed by a Apache2.0-style
+// license that can be found in the LICENSE file.
+
+package xdb
+
+import (
+	"testing"
+)
+
+// truncated content buffer (header only) must return an error instead of panicking
+func TestSearchTruncatedContentBuffer(t *testing.T) {
+	cBuff := make([]byte, HeaderInfoLength)
+	s, err := NewWithBuffer(IPv4, cBuff)
+	if err != nil {
+		t.Fatalf("failed to new searcher: %s", err)
+	}
+	defer s.Close()
+
+	if _, err := s.Search("1.2.3.4"); err == nil {
+		t.Fatal("expected error with truncated content buffer, got nil")
+	}
+}
+
+// content buffer truncated inside the vector index area must not panic
+func TestSearchContentBufferTruncatedInVectorIndex(t *testing.T) {
+	cBuff := make([]byte, HeaderInfoLength+100)
+	s, err := NewWithBuffer(IPv4, cBuff)
+	if err != nil {
+		t.Fatalf("failed to new searcher: %s", err)
+	}
+	defer s.Close()
+
+	if _, err := s.Search("1.2.3.4"); err == nil {
+		t.Fatal("expected error with content buffer truncated in vector index, got nil")
+	}
+}
+
+// too-short vector index must return an error instead of panicking
+func TestSearchTruncatedVectorIndex(t *testing.T) {
+	vIndex := make([]byte, 100)
+	s, err := NewWithVectorIndex(IPv4, "../../../data/ip2region_v4.xdb", vIndex)
+	if err != nil {
+		t.Fatalf("failed to new searcher: %s", err)
+	}
+	defer s.Close()
+
+	if _, err := s.Search("1.2.3.4"); err == nil {
+		t.Fatal("expected error with truncated vector index, got nil")
+	}
+}
+
+// sanity check: a full content buffer still searches correctly
+func TestSearchFullContentBuffer(t *testing.T) {
+	cBuff, err := LoadContentFromFile("../../../data/ip2region_v4.xdb")
+	if err != nil {
+		t.Fatalf("failed to load content: %s", err)
+	}
+
+	s, err := NewWithBuffer(IPv4, cBuff)
+	if err != nil {
+		t.Fatalf("failed to new searcher: %s", err)
+	}
+	defer s.Close()
+
+	region, err := s.Search("219.133.110.197")
+	if err != nil {
+		t.Fatalf("failed to search: %s", err)
+	}
+	if region == "" {
+		t.Fatal("empty region returned for a known ip")
+	}
+}


### PR DESCRIPTION
### 问题描述
`Searcher.Search()` 在读取 `vectorIndex` / `contentBuff` 时未检查 buffer 长度（`read()` 中 `s.contentBuff[offset:]` 同样未做边界校验）。当传入截断或损坏的 buffer 时——例如 embed 的 xdb 文件被截断，或调用方传入不完整的字节切片——会触发 `panic: slice bounds out of range`，而不是返回错误。

### 修复方案
- 向量索引查找：校验 `len(vectorIndex) >= idx+VectorIndexSize`；
- 内容 buffer 查找：校验 `len(contentBuff) >= HeaderInfoLength+idx+VectorIndexSize`；
- `read()`：校验 `0 <= offset 且 offset+len(buff) <= len(contentBuff)`。

三处越界点均改为返回带描述的 error。

### 测试（新增 `xdb/searcher_test.go`）
- `TestSearchTruncatedContentBuffer`：仅含 header 的 buffer → 返回错误，不 panic；
- `TestSearchContentBufferTruncatedInVectorIndex`：buffer 在向量索引区域被截断 → 返回错误，不 panic；
- `TestSearchTruncatedVectorIndex`：仅 100 字节的向量索引 → 返回错误，不 panic；
- `TestSearchFullContentBuffer`：完整 xdb 内容仍能正常查询（回归保护）。