### PR TITLE
fix (go): NewSearcherPool 创建中途失败时关闭已创建的 searcher，避免文件句柄泄漏

### DIFF
--- a/binding/golang/service/searcher_pool.go
+++ b/binding/golang/service/searcher_pool.go
@@ -42,6 +42,13 @@ func NewSearcherPool(config *Config) (*SearcherPool, error) {
 	for i := 0; i < config.searchers; i++ {
 		searcher, err := xdb.NewSearcher(config.ipVersion, config.xdbPath, config.vIndex, config.cBuffer)
 		if err != nil {
+			// close the searchers that were already created to
+			// avoid leaking the underlying file handles.
+			for j := 0; j < i; j++ {
+				s := <-pool
+				s.Close()
+			}
+
 			return nil, fmt.Errorf("failed to create the %dth searcher: %w", i+1, err)
 		}
 

--- a/binding/golang/service/searcher_pool_test.go
+++ b/binding/golang/service/searcher_pool_test.go
@@ -6,6 +6,7 @@ package service
 
 import (
 	"fmt"
+	"os"
 	"testing"
 	"time"
 )
@@ -97,4 +98,32 @@ func TestBorrowAfterClose(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Fatal("BorrowSearcher after close blocked forever")
 	}
+}
+
+func TestNewSearcherPoolCreateFailure(t *testing.T) {
+	const xdbPath = "../../../data/ip2region_v4.xdb"
+	const tmpPath = xdbPath + ".tmp"
+
+	cfg, err := NewV4Config(VIndexCache, xdbPath, 3)
+	if err != nil {
+		t.Fatalf("failed to new v4 config: %s", err)
+	}
+
+	// temporarily move the xdb file away so that re-opening it in
+	// NewSearcherPool fails, and make sure it is restored afterwards
+	if err := os.Rename(xdbPath, tmpPath); err != nil {
+		t.Fatalf("failed to move xdb file: %s", err)
+	}
+	defer func() {
+		if err := os.Rename(tmpPath, xdbPath); err != nil {
+			t.Errorf("failed to restore xdb file: %s", err)
+		}
+	}()
+
+	pool, err := NewSearcherPool(cfg)
+	if err == nil {
+		pool.Close()
+		t.Fatal("expected error from NewSearcherPool with missing xdb file")
+	}
+	t.Logf("NewSearcherPool failed as expected: %s", err)
 }


### PR DESCRIPTION
### 问题描述
`NewSearcherPool` 循环创建 searcher，第 i 个失败时直接返回错误，前 i-1 个已创建 searcher 持有的 xdb 文件句柄未关闭，造成泄漏。

### 修复方案
创建失败时，将 pool 中已创建的 searcher 全部取出并 `Close()`，再返回错误。

### 测试
- `TestNewSearcherPoolCreateFailure`：先创建有效 config，再临时移走 xdb 文件使 `NewSearcher` 打开失败，验证错误路径正常返回且不 panic，测试结束恢复文件。