### PR TITLE
fix (go): 修复 Searcher.Search 二分查找上界 h 的差一错误

### DIFF
--- a/binding/golang/xdb/binary_search_test.go
+++ b/binding/golang/xdb/binary_search_test.go
@@ -1,0 +1,93 @@
+// Copyright 2022 The Ip2Region Authors. All rights reserved.
+// Use of this source code is governed by a Apache2.0-style
+// license that can be found in the LICENSE file.
+
+package xdb
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// buildTestXdbContent builds a minimal IPv4 xdb content in memory:
+//
+//	- 256-byte header (Structure20)
+//	- a full vector index block, only cell (1,1) is filled
+//	- one segment index entry: [1.1.1.0, 1.1.1.255] -> region "test"
+//	- the region data right after the segment index
+//
+// The total content is sized so that reading past the last segment index
+// (i.e. at the region area) with a full segment-index-sized buffer would
+// fail, which lets the tests catch the binary-search upper-bound bug.
+func buildTestXdbContent(t *testing.T) []byte {
+	t.Helper()
+
+	segIndexSize := IPv4.SegmentIndexSize
+	segStart := HeaderInfoLength + VectorIndexRows*VectorIndexCols*VectorIndexSize
+	segEnd := segStart + segIndexSize
+	region := "test"
+
+	content := make([]byte, segEnd+len(region))
+
+	// header
+	binary.LittleEndian.PutUint16(content[0:], Structure20)
+	binary.LittleEndian.PutUint16(content[2:], uint16(VectorIndexPolicy))
+	binary.LittleEndian.PutUint32(content[4:], 0)
+	binary.LittleEndian.PutUint32(content[8:], uint32(segStart))
+	binary.LittleEndian.PutUint32(content[12:], uint32(segEnd))
+	binary.LittleEndian.PutUint16(content[16:], uint16(IPv4VersionNo))
+	binary.LittleEndian.PutUint16(content[18:], 4)
+
+	// vector index cell (1,1) -> segment index area
+	idx := 1*VectorIndexCols*VectorIndexSize + 1*VectorIndexSize
+	binary.LittleEndian.PutUint32(content[HeaderInfoLength+idx:], uint32(segStart))
+	binary.LittleEndian.PutUint32(content[HeaderInfoLength+idx+4:], uint32(segEnd))
+
+	// segment index: start 1.1.1.0, end 1.1.1.255, stored little-endian
+	binary.LittleEndian.PutUint32(content[segStart:], binary.BigEndian.Uint32([]byte{1, 1, 1, 0}))
+	binary.LittleEndian.PutUint32(content[segStart+4:], binary.BigEndian.Uint32([]byte{1, 1, 1, 255}))
+	binary.LittleEndian.PutUint16(content[segStart+8:], uint16(len(region)))
+	binary.LittleEndian.PutUint32(content[segStart+10:], uint32(segEnd))
+
+	// region data
+	copy(content[segEnd:], region)
+
+	return content
+}
+
+// an ip inside the segment must be found
+func TestBinarySearchHit(t *testing.T) {
+	s, err := NewWithBuffer(IPv4, buildTestXdbContent(t))
+	if err != nil {
+		t.Fatalf("failed to new searcher: %s", err)
+	}
+	defer s.Close()
+
+	region, err := s.Search("1.1.1.100")
+	if err != nil {
+		t.Fatalf("failed to search: %s", err)
+	}
+	if region != "test" {
+		t.Fatalf("unexpected region `%s`, `test` expected", region)
+	}
+}
+
+// an ip inside the same vector index cell but outside any segment
+// must return an empty region without error. Before the fix, the binary
+// search upper bound was N (one past the last index), so it read past
+// the segment index area and failed on the tiny region buffer.
+func TestBinarySearchMissInCell(t *testing.T) {
+	s, err := NewWithBuffer(IPv4, buildTestXdbContent(t))
+	if err != nil {
+		t.Fatalf("failed to new searcher: %s", err)
+	}
+	defer s.Close()
+
+	region, err := s.Search("1.1.2.1")
+	if err != nil {
+		t.Fatalf("expected empty region for a gap ip, got error: %s", err)
+	}
+	if region != "" {
+		t.Fatalf("expected empty region, got `%s`", region)
+	}
+}

--- a/binding/golang/xdb/searcher.go
+++ b/binding/golang/xdb/searcher.go
@@ -165,7 +165,9 @@ func (s *Searcher) Search(ip any) (string, error) {
 	var segIndexSize = uint32(s.version.SegmentIndexSize)
 	var dataLen, dataPtr = 0, uint32(0)
 	var buff = make([]byte, segIndexSize)
-	var l, h = 0, int((ePtr - sPtr) / segIndexSize)
+	// the segment index entries are numbered [0, N-1], so the upper bound
+	// is N-1. N (=0) means an empty index, the loop will be skipped safely.
+	var l, h = 0, int((ePtr-sPtr)/segIndexSize) - 1
 	for l <= h {
 		m := (l + h) >> 1
 		p := sPtr + uint32(m)*segIndexSize


### PR DESCRIPTION
### 问题描述
`Searcher.Search` 二分查找的初始上界 `h = (ePtr - sPtr) / segIndexSize`，而段索引实际编号为 `[0, N-1]`，上界应为 **N-1**。h=N 引入一个虚拟位置，当查询 IP 落在格子尾部空洞时，二分会多读一次 `p = ePtr`（region 数据区）的位置——对极小 xdb（region 区不足 14 字节）会误报 "incomplete read"，对正常文件则是多余的一次磁盘 IO。

### 修复方案
将上界改为 `int((ePtr-sPtr)/segIndexSize) - 1`；N=0 时 h=-1，
二分循环被安全跳过（不越界读）。

### 测试（新增 `xdb/binary_search_test.go`，构造最小 xdb 内存结构）
- `TestBinarySearchHit`：段内 IP 正常命中；
- `TestBinarySearchMissInCell`：格子内空洞 IP 返回空结果、不报错。
  （已验证：修复前该测试失败，报 `incomplete read: readed bytes should be 14`）