### PR TITLE
fix (go): 当所有借出的 searcher 归还后 CloseTimeout 立即返回，不再空等整个超时周期

### DIFF
--- a/binding/golang/service/searcher_pool.go
+++ b/binding/golang/service/searcher_pool.go
@@ -28,6 +28,11 @@ type SearcherPool struct {
 	// for pool close
 	closing chan struct{}
 
+	// notify the close process that a loaned searcher was returned
+	// and closed, so CloseTimeout can bail out as soon as all the
+	// loaned searchers are back instead of waiting the full timeout.
+	returned chan struct{}
+
 	// searcher number that was loaned out
 	loanCount int32
 }
@@ -54,6 +59,7 @@ func NewSearcherPool(config *Config) (*SearcherPool, error) {
 		pool:   pool,
 
 		closing:   make(chan struct{}, 1),
+		returned:  make(chan struct{}, config.searchers+1),
 		loanCount: 0,
 	}, nil
 }
@@ -83,6 +89,13 @@ func (sp *SearcherPool) ReturnSearcher(searcher *xdb.Searcher) {
 
 		// decrease the loan count
 		atomic.AddInt32(&sp.loanCount, -1)
+
+		// notify the close process so it can bail out as soon as
+		// every loaned searcher is back, avoid waiting the full timeout.
+		select {
+		case sp.returned <- struct{}{}:
+		default:
+		}
 	default:
 		// return the searcher
 		sp.pool <- searcher
@@ -102,22 +115,19 @@ func (sp *SearcherPool) CloseTimeout(d time.Duration) {
 	defer timer.Stop()
 
 	for {
-		timeout := false
-		select {
-		case s := <-sp.pool:
-			s.Close()
-		case <-timer.C:
-			// check if all the loaned searchers was closed
-			timeout = true
-		}
-
+		// all the searchers are closed already, done
 		lc, left := sp.LoanCount(), len(sp.pool)
 		if left == 0 && lc == 0 {
 			break
 		}
 
-		if timeout {
-			break
+		select {
+		case s := <-sp.pool:
+			s.Close()
+		case <-sp.returned:
+			// a loaned searcher was returned and closed, re-check
+		case <-timer.C:
+			return
 		}
 	}
 }

--- a/binding/golang/service/searcher_pool_test.go
+++ b/binding/golang/service/searcher_pool_test.go
@@ -98,3 +98,40 @@ func TestBorrowAfterClose(t *testing.T) {
 		t.Fatal("BorrowSearcher after close blocked forever")
 	}
 }
+
+func TestCloseTimeoutReturnsEarlyWhenAllLoaned(t *testing.T) {
+	v4Config, err := NewV4Config(VIndexCache, "../../../data/ip2region_v4.xdb", 2)
+	if err != nil {
+		t.Fatalf("failed to new v4 config: %s", err)
+	}
+
+	searcherPool, err := NewSearcherPool(v4Config)
+	if err != nil {
+		t.Fatalf("failed to create searcher pool: %s", err)
+	}
+
+	// borrow all the searchers
+	s1 := searcherPool.BorrowSearcher()
+	s2 := searcherPool.BorrowSearcher()
+	if s1 == nil || s2 == nil {
+		t.Fatal("failed to borrow searchers")
+	}
+
+	// close the pool while all the searchers are loaned out;
+	// returning them must let CloseTimeout finish well before the timeout
+	done := make(chan struct{})
+	go func() {
+		searcherPool.CloseTimeout(10 * time.Second)
+		close(done)
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+	searcherPool.ReturnSearcher(s1)
+	searcherPool.ReturnSearcher(s2)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("CloseTimeout did not return early after all loaned searchers were returned")
+	}
+}


### PR DESCRIPTION
### 问题描述
当 `SearcherPool` 的所有 searcher 都被借出时调用 `CloseTimeout(d)`，即使借出的 searcher 已在归还时被关闭（loanCount 归零），关闭循环仍阻塞在`<-sp.pool` 上无法感知状态变化，只能干等到超时周期结束。实测 `CloseTimeout(10s)` 实际阻塞 10.003s，拖慢程序退出路径。

### 修复方案
- 为 `SearcherPool` 增加 `returned` 信号通道；
- `ReturnSearcher` 在关闭分支（归还且关闭 searcher）后发送非阻塞信号；
- `CloseTimeout` 的 select 监听该信号，收到后重新检查循环条件；
- 循环开头增加快速退出判断：`len(pool) == 0 && LoanCount() == 0` 时立即返回。

### 测试
- `TestCloseTimeoutReturnsEarlyWhenAllLoaned`：借出全部 searcher 后启动
  `CloseTimeout(10s)`，归还后应在 2 秒内返回（修复前需要 10 秒）。
