### PR TITLE
fix (go): VersionFromHeader 错误消息打印正确的字段值

### DIFF
--- a/binding/golang/xdb/version.go
+++ b/binding/golang/xdb/version.go
@@ -97,7 +97,7 @@ func VersionFromHeader(header *Header) (*Version, error) {
 
 	// structure 3.0 after IPv6 supporting
 	if header.Version != Structure30 {
-		return IPvx, fmt.Errorf("invalid version `%d`", header.IPVersion)
+		return IPvx, fmt.Errorf("invalid version `%d`", header.Version)
 	}
 
 	switch header.IPVersion {
@@ -106,6 +106,6 @@ func VersionFromHeader(header *Header) (*Version, error) {
 	case IPv6VersionNo:
 		return IPv6, nil
 	default:
-		return IPvx, fmt.Errorf("invalid version `%d`", header.Version)
+		return IPvx, fmt.Errorf("invalid version `%d`", header.IPVersion)
 	}
 }

--- a/binding/golang/xdb/version_test.go
+++ b/binding/golang/xdb/version_test.go
@@ -6,6 +6,7 @@ package xdb
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 )
 
@@ -41,5 +42,29 @@ func TestIPv4IPCompare(t *testing.T) {
 		if (r < 0 && c.exp >= 0) || (r == 0 && c.exp != 0) || (r > 0 && c.exp <= 0) {
 			t.Errorf("IPv4.IPCompare(%v, %v) = %d, sign %d expected", c.ip1, c.ip2, r, c.exp)
 		}
+	}
+}
+
+func TestVersionFromHeaderInvalidVersion(t *testing.T) {
+	// an unknown structure version must be reported with the version field value
+	h := &Header{Version: 99, IPVersion: 4}
+	_, err := VersionFromHeader(h)
+	if err == nil {
+		t.Fatal("expected error with invalid structure version")
+	}
+	if !strings.Contains(err.Error(), "99") {
+		t.Fatalf("error `%s` does not contain the invalid version value 99", err)
+	}
+}
+
+func TestVersionFromHeaderInvalidIPVersion(t *testing.T) {
+	// an unknown ip version must be reported with the ip version field value
+	h := &Header{Version: Structure30, IPVersion: 5}
+	_, err := VersionFromHeader(h)
+	if err == nil {
+		t.Fatal("expected error with invalid ip version")
+	}
+	if !strings.Contains(err.Error(), "5") {
+		t.Fatalf("error `%s` does not contain the invalid ip version value 5", err)
 	}
 }


### PR DESCRIPTION
### 问题描述
`VersionFromHeader` 两处错误消息打印的字段互换：
- 结构版本无效（`header.Version != Structure30`）时打印的是 `header.IPVersion`；
- IP 版本无效（非 4/6）时打印的是 `header.Version`。

排查问题时错误消息展示的数值与实际无效字段不一致，误导定位。

### 修复方案
两处错误消息改为打印实际无效的字段值。

### 测试（`xdb/version_test.go`）
- `TestVersionFromHeaderInvalidVersion`：Version=99 时错误消息包含 "99"；
- `TestVersionFromHeaderInvalidIPVersion`：Structure30 + IPVersion=5 时
  错误消息包含 "5"。