### PR TITLE
fix(cpp): support native Windows builds

### DIFF
--- a/binding/cpp/CMakeLists.txt
+++ b/binding/cpp/CMakeLists.txt
@@ -1,0 +1,70 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(ip2region_cpp LANGUAGES CXX)
+
+option(IP2REGION_BUILD_TOOLS "Build the C++ command-line tools" ON)
+
+add_library(
+    ip2region_xdb
+    src/base.cc
+    src/bench.cc
+    src/edit.cc
+    src/header.cc
+    src/ip.cc
+    src/make.cc
+    src/search.cc
+)
+
+target_compile_features(ip2region_xdb PUBLIC cxx_std_11)
+target_include_directories(ip2region_xdb PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/src")
+
+if(MSVC)
+    target_compile_options(ip2region_xdb PRIVATE /W4 /permissive-)
+else()
+    target_compile_options(ip2region_xdb PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
+if(WIN32)
+    target_compile_definitions(ip2region_xdb PRIVATE _WIN32_WINNT=0x0600)
+    target_link_libraries(ip2region_xdb PUBLIC ws2_32)
+endif()
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/bin")
+foreach(config DEBUG RELEASE RELWITHDEBINFO MINSIZEREL)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_${config} "${CMAKE_CURRENT_SOURCE_DIR}/bin")
+endforeach()
+
+function(add_xdb_executable target source output_name)
+    add_executable(${target} ${source})
+    target_link_libraries(${target} PRIVATE ip2region_xdb)
+    set_target_properties(${target} PROPERTIES OUTPUT_NAME ${output_name})
+endfunction()
+
+if(IP2REGION_BUILD_TOOLS)
+    add_xdb_executable(xdb_header test/header.cc header)
+    add_xdb_executable(xdb_search test/search.cc search)
+    add_xdb_executable(xdb_bench test/bench.cc bench)
+    add_xdb_executable(xdb_make test/make.cc make)
+    add_xdb_executable(edit_v4 test/edit_v4.cc edit_v4)
+    add_xdb_executable(edit_v6 test/edit_v6.cc edit_v6)
+endif()
+
+include(CTest)
+
+if(BUILD_TESTING)
+    add_xdb_executable(ip_test test/ip.cc ip_test)
+
+    add_test(NAME cpp.ip COMMAND ip_test)
+    set_tests_properties(cpp.ip PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+
+    if(IP2REGION_BUILD_TOOLS)
+        add_test(NAME cpp.header COMMAND xdb_header)
+        add_test(NAME cpp.search COMMAND xdb_search)
+        add_test(NAME cpp.make COMMAND xdb_make)
+
+        set_tests_properties(
+            cpp.header cpp.search cpp.make
+            PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        )
+    endif()
+endif()

--- a/binding/cpp/CMakeLists.txt
+++ b/binding/cpp/CMakeLists.txt
@@ -60,11 +60,23 @@ if(BUILD_TESTING)
     if(IP2REGION_BUILD_TOOLS)
         add_test(NAME cpp.header COMMAND xdb_header)
         add_test(NAME cpp.search COMMAND xdb_search)
-        add_test(NAME cpp.make COMMAND xdb_make)
+        set(cpp_make_output_directory "${CMAKE_CURRENT_BINARY_DIR}/test-output")
+        file(MAKE_DIRECTORY "${cpp_make_output_directory}")
+        add_test(
+            NAME cpp.make
+            COMMAND
+                xdb_make
+                "${CMAKE_CURRENT_SOURCE_DIR}/test/fixtures"
+                "${cpp_make_output_directory}"
+        )
 
         set_tests_properties(
-            cpp.header cpp.search cpp.make
+            cpp.header cpp.search
             PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        )
+        set_tests_properties(
+            cpp.make
+            PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
         )
     endif()
 endif()

--- a/binding/cpp/Makefile
+++ b/binding/cpp/Makefile
@@ -1,27 +1,25 @@
 
-all: bin header search bench make edit
+CMAKE ?= cmake
+BUILD_DIR ?= build
+BUILD_TYPE ?= Release
 
-FILES=$(wildcard src/*.cc)
+.PHONY: all configure header search bench make edit test clean
 
-bin:
-	mkdir -p bin
+all: configure
+	$(CMAKE) --build $(BUILD_DIR) --config $(BUILD_TYPE) --parallel
 
-header: $(FILES) test/header.cc
-	g++ -std=c++11 -O2 $^ -o bin/$@
+configure:
+	$(CMAKE) -S . -B $(BUILD_DIR) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE)
 
-search: $(FILES) test/search.cc
-	g++ -std=c++11 -O2 $^ -o bin/$@
+header search bench make: configure
+	$(CMAKE) --build $(BUILD_DIR) --config $(BUILD_TYPE) --target xdb_$@ --parallel
 
-bench: $(FILES) test/bench.cc
-	g++ -std=c++11 -O2 $^ -o bin/$@
+edit: configure
+	$(CMAKE) --build $(BUILD_DIR) --config $(BUILD_TYPE) --target edit_v4 edit_v6 --parallel
 
-make: $(FILES) test/make.cc
-	g++ -std=c++11 -O2 $^ -o bin/$@
-
-edit: $(FILES)
-	g++ -std=c++11 -O2 $^ test/edit_v4.cc -o bin/edit_v4
-	g++ -std=c++11 -O2 $^ test/edit_v6.cc -o bin/edit_v6
+test: all
+	ctest --test-dir $(BUILD_DIR) -C $(BUILD_TYPE) --output-on-failure
 
 clean:
-	rm -rf bin
-
+	$(CMAKE) -E remove_directory $(BUILD_DIR)
+	$(CMAKE) -E remove_directory bin

--- a/binding/cpp/README.md
+++ b/binding/cpp/README.md
@@ -37,11 +37,23 @@ readme.md --------- readme
 
 ```
 
-## 1. Compilation
+## 1. Build and Test
 
+The C++ binding uses CMake 3.16 or later and supports GCC, Clang, Apple Clang,
+and Microsoft Visual C++.
+
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build --config Release --parallel
+ctest --test-dir build -C Release --output-on-failure
 ```
-$ make
-```
+
+On Linux and macOS, `make` and `make test` are equivalent convenience entry
+points. On Windows, run the commands above from a Visual Studio Developer
+PowerShell. CMake links the required Windows Sockets library automatically.
+
+The test suite validates IPv4 and IPv6 address conversion, xdb headers, every
+search cache policy, and queries against freshly generated xdb files.
 
 ## 2. Search
 

--- a/binding/cpp/README_zh.md
+++ b/binding/cpp/README_zh.md
@@ -35,10 +35,23 @@ bin/edit_v6 ------- 测试 原始数据编辑(ipv6)
 readme.md --------- readme
 ```
 
-## 1. 编译
+## 1. 构建与测试
+
+C++ binding 使用 CMake 3.16 或更高版本，支持 GCC、Clang、Apple Clang 和
+Microsoft Visual C++。
+
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build --config Release --parallel
+ctest --test-dir build -C Release --output-on-failure
 ```
-$ make
-```
+
+在 Linux 和 macOS 上，`make` 与 `make test` 分别是对应构建和测试命令的便捷
+入口。在 Windows 上，请从 Visual Studio Developer PowerShell 运行上述命令；
+CMake 会自动链接所需的 Windows Sockets 库。
+
+测试套件会验证 IPv4/IPv6 地址转换、xdb header、全部搜索缓存策略，并查询刚刚
+生成的 xdb 文件。
 
 ## 2. 查找
 ### 2.1 示例

--- a/binding/cpp/src/base.cc
+++ b/binding/cpp/src/base.cc
@@ -20,6 +20,15 @@ void log_exit(const string &msg) {
     exit(-1);
 }
 
+FILE *open_file(const string &path, const char *mode) {
+#ifdef _MSC_VER
+    FILE *file = NULL;
+    return fopen_s(&file, path.c_str(), mode) == 0 ? file : NULL;
+#else
+    return fopen(path.c_str(), mode);
+#endif
+}
+
 void read_bin(int index, char *buf, size_t len, FILE *db) {
     fseek(db, index, SEEK_SET);
     if (fread(buf, 1, len, db) != len)
@@ -27,12 +36,15 @@ void read_bin(int index, char *buf, size_t len, FILE *db) {
 }
 
 unsigned to_uint(const char *buf) {
-    return ((buf[0]) & 0x000000FF) | ((buf[1] << 8) & 0x0000FF00) |
-           ((buf[2] << 16) & 0x00FF0000) | ((buf[3] << 24) & 0xFF000000);
+    return static_cast<unsigned char>(buf[0]) |
+           (static_cast<unsigned>(static_cast<unsigned char>(buf[1])) << 8) |
+           (static_cast<unsigned>(static_cast<unsigned char>(buf[2])) << 16) |
+           (static_cast<unsigned>(static_cast<unsigned char>(buf[3])) << 24);
 }
 
 unsigned to_ushort(const char *buf) {
-    return ((buf[0]) & 0x000000FF) | ((buf[1] << 8) & 0x0000FF00);
+    return static_cast<unsigned char>(buf[0]) |
+           (static_cast<unsigned>(static_cast<unsigned char>(buf[1])) << 8);
 }
 
 unsigned to_int(const char *buf, int n) {

--- a/binding/cpp/src/base.cc
+++ b/binding/cpp/src/base.cc
@@ -1,6 +1,8 @@
 
 #include "base.h"
 
+#include <chrono>
+
 namespace xdb {
 
 int ip_version;  // ip 版本
@@ -66,9 +68,11 @@ void write_string(const char *buf, unsigned len, FILE *dst) {
 }
 
 unsigned long long get_time() {
-    struct timeval tv1;
-    gettimeofday(&tv1, NULL);
-    return (unsigned long long)tv1.tv_sec * 1000 * 1000 + tv1.tv_usec;
+    using std::chrono::duration_cast;
+    using std::chrono::microseconds;
+    using std::chrono::steady_clock;
+
+    return duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count();
 }
 
 }  // namespace xdb

--- a/binding/cpp/src/base.h
+++ b/binding/cpp/src/base.h
@@ -36,6 +36,8 @@ void init_xdb(int version);
 
 void log_exit(const string &msg);
 
+FILE *open_file(const string &path, const char *mode);
+
 void read_bin(int index, char *buf, size_t len, FILE *db);
 
 unsigned to_uint(const char *buf);

--- a/binding/cpp/src/base.h
+++ b/binding/cpp/src/base.h
@@ -1,11 +1,10 @@
 #ifndef BASE_H
 #define BASE_H
 
-#include <arpa/inet.h>
+#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
 
 #include <algorithm>
 #include <iostream>

--- a/binding/cpp/src/bench.cc
+++ b/binding/cpp/src/bench.cc
@@ -32,7 +32,7 @@ void bench_t::test_line(char *buf) {
 }
 
 void bench_t::test_file(const std::string &file_name) {
-    FILE *f = fopen(file_name.data(), "r");
+    FILE *f = open_file(file_name, "r");
     if (f == NULL)
         xdb::log_exit("can't open " + file_name);
     char buf[1024];

--- a/binding/cpp/src/edit.cc
+++ b/binding/cpp/src/edit.cc
@@ -4,13 +4,13 @@
 namespace xdb {
 
 void handle_ip_txt(const string& name, std::list<node_t>& regions) {
-    FILE* f = fopen(name.data(), "r");
+    FILE* f = open_file(name, "r");
     if (f == NULL)
         log_exit("can't open " + name);
 
     char buf[1024];
     while (fgets(buf, sizeof(buf), f) != NULL) {
-        unsigned int buf_len = strlen(buf);
+        size_t buf_len = strlen(buf);
         // 去掉多余的空
         while (buf_len > 0 && isspace(buf[buf_len - 1]))
             --buf_len;
@@ -108,7 +108,7 @@ void edit_t::merge() {
 }
 
 void edit_t::write_old_file(const std::string& file_name) {
-    FILE* f = fopen(file_name.data(), "w");
+    FILE* f = open_file(file_name, "w");
     if (f == NULL)
         log_exit("can't open " + file_name);
 

--- a/binding/cpp/src/ip.cc
+++ b/binding/cpp/src/ip.cc
@@ -1,6 +1,42 @@
 
 #include "ip.h"
 
+#ifdef _WIN32
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600
+#endif
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <arpa/inet.h>
+#endif
+
+namespace {
+
+bool parse_ip_address(int family, const std::string& address, void* destination) {
+#ifdef _WIN32
+    return InetPtonA(family, address.c_str(), destination) == 1;
+#else
+    return inet_pton(family, address.c_str(), destination) == 1;
+#endif
+}
+
+const char* format_ip_address(int family,
+                              const void* address,
+                              char* destination,
+                              size_t destination_size) {
+#ifdef _WIN32
+    return InetNtopA(family,
+                     const_cast<void*>(address),
+                     destination,
+                     static_cast<DWORD>(destination_size));
+#else
+    return inet_ntop(family, address, destination, destination_size);
+#endif
+}
+
+}  // namespace
+
 namespace xdb {
 
 ip_t::ip_t() {
@@ -21,7 +57,7 @@ ip_t::ip_t(const char* p) {
 
 bool ip_t::from_str(const string& str) {
     int af_inet = ip_version == ipv4 ? AF_INET : AF_INET6;
-    return inet_pton(af_inet, str.data(), p) == 1;
+    return parse_ip_address(af_inet, str, p);
 }
 
 void ip_t::from_xdb(const char str[16]) {
@@ -74,7 +110,8 @@ bool ip_t::operator!=(const ip_t& rhs) const {
 string ip_t::to_string() const {
     char buf[INET6_ADDRSTRLEN + 1];
     int  af_inet = ip_version == ipv4 ? AF_INET : AF_INET6;
-    inet_ntop(af_inet, p, buf, sizeof(buf));
+    if (format_ip_address(af_inet, p, buf, sizeof(buf)) == NULL)
+        log_exit("failed to format ipv" + std::to_string(ip_version));
     return string(buf);
 }
 

--- a/binding/cpp/src/make.cc
+++ b/binding/cpp/src/make.cc
@@ -75,7 +75,7 @@ void make_t::handle_input_help(char *buf) {
 }
 
 void make_t::handle_input(const std::string &file_name) {
-    FILE *src = fopen(file_name.data(), "r");
+    FILE *src = open_file(file_name, "r");
     if (src == NULL)
         log_exit("can't open " + file_name);
 
@@ -151,7 +151,7 @@ make_t::make_t(const string &src, const string &dst, int version)
 
     handle_input(src);
 
-    db = fopen(dst.c_str(), "wb");
+    db = open_file(dst, "wb");
     if (db == NULL)
         log_exit("can't open " + dst);
 

--- a/binding/cpp/src/make.cc
+++ b/binding/cpp/src/make.cc
@@ -1,6 +1,8 @@
 
 #include "make.h"
 
+#include <ctime>
+
 namespace xdb {
 
 void make_t::vector_index_push_back(int row, int col, const node_t &node) {
@@ -149,7 +151,7 @@ make_t::make_t(const string &src, const string &dst, int version)
 
     handle_input(src);
 
-    db = fopen(dst.data(), "w");
+    db = fopen(dst.c_str(), "wb");
     if (db == NULL)
         log_exit("can't open " + dst);
 

--- a/binding/cpp/src/make.cc
+++ b/binding/cpp/src/make.cc
@@ -5,8 +5,12 @@
 
 namespace xdb {
 
+make_t::vector_bucket_t &make_t::vector_bucket(unsigned row, unsigned col) {
+    return vector_index[row * 256 + col];
+}
+
 void make_t::vector_index_push_back(int row, int col, const node_t &node) {
-    vector_index[row][col].push_back(
+    vector_bucket(row, col).push_back(
         std::make_pair<string, string>(node.to_bit(), string(node.region)));
 }
 
@@ -99,7 +103,7 @@ void make_t::handle_header() {
 
     for (int i = 0; i < 256; ++i)
         for (int j = 0; j < 256; ++j)
-            content_right += vector_index[i][j].size() * content_size;
+            content_right += vector_bucket(i, j).size() * content_size;
     content_right -= content_size;
     write_uint(content_left, buf + 8);
     write_uint(content_right, buf + 12);
@@ -115,12 +119,12 @@ void make_t::handle_vector_index() {
         index += d.first.size();
     for (unsigned i = 0; i < 256; ++i)
         for (unsigned j = 0; j < 256; ++j)
-            if (vector_index[i][j].size() == 0) {
+            if (vector_bucket(i, j).empty()) {
                 write_uint(0, db);
                 write_uint(0, db);
             } else {
                 write_uint(index, db);
-                index += content_size * vector_index[i][j].size();
+                index += content_size * vector_bucket(i, j).size();
                 write_uint(index, db);
             }
 }
@@ -136,7 +140,7 @@ void make_t::handle_content() {
     fseek(db, 0, SEEK_END);
     for (unsigned i = 0; i < 256; ++i)
         for (unsigned j = 0; j < 256; ++j)
-            for (auto d : vector_index[i][j]) {
+            for (const auto &d : vector_bucket(i, j)) {
                 write_string(d.first.data(), d.first.size(), db);
                 write_ushort(d.second.size(), db);
                 write_uint(region[d.second], db);
@@ -144,7 +148,7 @@ void make_t::handle_content() {
 }
 
 make_t::make_t(const string &src, const string &dst, int version)
-    : region_index(length_vector + length_header) {
+    : vector_index(256 * 256), region_index(length_vector + length_header) {
     unsigned long long tv1 = get_time();
 
     init_xdb(version);

--- a/binding/cpp/src/make.h
+++ b/binding/cpp/src/make.h
@@ -10,6 +10,10 @@ public:
     make_t(const string &src, const string &dst, int version);
 
 private:
+    using vector_bucket_t = std::vector<std::pair<string, string>>;
+
+    vector_bucket_t &vector_bucket(unsigned row, unsigned col);
+
     void vector_index_push_back(int row, int col, const node_t &node);
     void vector_index_push_back(node_t &node);
     void handle_input_help(char buf[]);
@@ -22,7 +26,7 @@ private:
 
     FILE *db = NULL;
 
-    std::vector<std::pair<string, string>> vector_index[256][256];
+    std::vector<vector_bucket_t> vector_index;
 
     std::unordered_map<string, unsigned> region;
 

--- a/binding/cpp/src/search.cc
+++ b/binding/cpp/src/search.cc
@@ -4,7 +4,7 @@
 namespace {
 
 FILE* open_database(const xdb::string& file) {
-    FILE* db = fopen(file.c_str(), "rb");
+    FILE* db = xdb::open_file(file, "rb");
     if (db == NULL)
         xdb::log_exit("can't open " + file);
     return db;

--- a/binding/cpp/src/search.cc
+++ b/binding/cpp/src/search.cc
@@ -1,14 +1,23 @@
 
 #include "search.h"
 
+namespace {
+
+FILE* open_database(const xdb::string& file) {
+    FILE* db = fopen(file.c_str(), "rb");
+    if (db == NULL)
+        xdb::log_exit("can't open " + file);
+    return db;
+}
+
+}  // namespace
+
 namespace xdb {
 
 search_t::search_t(const string &file, int version, int p)
-    : db(fopen(file.data(), "r")), header(db), policy(p) {
+    : db(open_database(file)), header(db), policy(p) {
     init_xdb(version);
 
-    if (db == NULL)
-        log_exit("can't open " + file);
     if (header.ip_version() != version)
         log_exit("ip 版本不匹配");
 

--- a/binding/cpp/test/fixtures/ipv4_source.txt
+++ b/binding/cpp/test/fixtures/ipv4_source.txt
@@ -1,0 +1,3 @@
+0.0.0.0|1.2.2.255|Reserved|Reserved|Reserved|0|ZZ
+1.2.3.0|1.2.3.255|Example|Documentation|Fixture|Test ISP|EX
+1.2.4.0|255.255.255.255|Reserved|Reserved|Reserved|0|ZZ

--- a/binding/cpp/test/fixtures/ipv6_source.txt
+++ b/binding/cpp/test/fixtures/ipv6_source.txt
@@ -1,0 +1,3 @@
+::|2001:db7:ffff:ffff:ffff:ffff:ffff:ffff|Reserved|Reserved|Reserved|0|ZZ
+2001:db8::|2001:db8::ffff|Example|Documentation|Fixture|Test ISP|EX
+2001:db8::1:0|ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff|Reserved|Reserved|Reserved|0|ZZ

--- a/binding/cpp/test/header.cc
+++ b/binding/cpp/test/header.cc
@@ -4,7 +4,11 @@
 void test(const std::string& prompt, const std::string& file_name) {
     std::cout << prompt << std::endl;
 
-    xdb::header_t head(fopen(file_name.data(), "r"));
+    FILE* db = fopen(file_name.c_str(), "rb");
+    if (db == NULL)
+        xdb::log_exit("can't open " + file_name);
+    xdb::header_t head(db);
+    fclose(db);
 
     std::cout << "版本号: " << head.version() << std::endl;
     std::cout << "缓存策略: " << head.index_policy() << std::endl;

--- a/binding/cpp/test/header.cc
+++ b/binding/cpp/test/header.cc
@@ -4,7 +4,7 @@
 void test(const std::string& prompt, const std::string& file_name) {
     std::cout << prompt << std::endl;
 
-    FILE* db = fopen(file_name.c_str(), "rb");
+    FILE* db = xdb::open_file(file_name, "rb");
     if (db == NULL)
         xdb::log_exit("can't open " + file_name);
     xdb::header_t head(db);

--- a/binding/cpp/test/ip.cc
+++ b/binding/cpp/test/ip.cc
@@ -1,0 +1,23 @@
+#include "../src/ip.h"
+
+void expect_round_trip(int version, const std::string& address) {
+    xdb::init_xdb(version);
+
+    xdb::ip_t ip;
+    if (!ip.from_str(address))
+        xdb::log_exit("failed to parse " + address);
+    if (ip.to_string() != address)
+        xdb::log_exit("round trip mismatch for " + address);
+}
+
+int main() {
+    expect_round_trip(xdb::ipv4, "192.0.2.1");
+    expect_round_trip(xdb::ipv6, "2001:db8::1");
+
+    xdb::init_xdb(xdb::ipv4);
+    xdb::ip_t invalid;
+    if (invalid.from_str("not-an-ip"))
+        xdb::log_exit("accepted an invalid IPv4 address");
+
+    return 0;
+}

--- a/binding/cpp/test/ip.cc
+++ b/binding/cpp/test/ip.cc
@@ -10,7 +10,26 @@ void expect_round_trip(int version, const std::string& address) {
         xdb::log_exit("round trip mismatch for " + address);
 }
 
+void expect_binary_decoding() {
+    const char uint_bytes[] = {
+        static_cast<char>(0x89),
+        static_cast<char>(0xAB),
+        static_cast<char>(0xCD),
+        static_cast<char>(0xEF),
+    };
+    const char ushort_bytes[] = {
+        static_cast<char>(0xCD),
+        static_cast<char>(0xEF),
+    };
+
+    if (xdb::to_uint(uint_bytes) != 0xEFCDAB89U)
+        xdb::log_exit("failed to decode a 32-bit value with high bits");
+    if (xdb::to_ushort(ushort_bytes) != 0xEFCDU)
+        xdb::log_exit("failed to decode a 16-bit value with high bits");
+}
+
 int main() {
+    expect_binary_decoding();
     expect_round_trip(xdb::ipv4, "192.0.2.1");
     expect_round_trip(xdb::ipv6, "2001:db8::1");
 

--- a/binding/cpp/test/make.cc
+++ b/binding/cpp/test/make.cc
@@ -1,5 +1,6 @@
 
 #include "../src/make.h"
+#include "../src/search.h"
 
 void test(const std::string& prompt,
           const std::string& filename_xdb,
@@ -9,6 +10,15 @@ void test(const std::string& prompt,
 ) {
     std::cout << prompt;
     xdb::make_t(filename_xdb, filename_src, version);
+}
+
+void expect_region(const std::string& filename_xdb,
+                   int version,
+                   const std::string& ip,
+                   const std::string& region) {
+    xdb::search_t search(filename_xdb, version, xdb::policy_content);
+    if (search.search(ip) != region)
+        xdb::log_exit("generated xdb query failed for " + ip);
 }
 
 int main() {
@@ -21,6 +31,15 @@ int main() {
          "../../data/ipv6_source.txt",
          "./ip2region_v6.xdb",
          xdb::ipv6);
+
+    expect_region("./ip2region_v4.xdb",
+                  xdb::ipv4,
+                  "1.2.3.4",
+                  "Australia|Queensland|Brisbane|0|AU");
+    expect_region("./ip2region_v6.xdb",
+                  xdb::ipv6,
+                  "2001:200:124::",
+                  "Japan|Tokyo|Asagaya-minami|WIDE Project|JP");
 
     return 0;
 }

--- a/binding/cpp/test/make.cc
+++ b/binding/cpp/test/make.cc
@@ -47,14 +47,18 @@ int main(int argc, char* argv[]) {
              xdb::ipv6);
 
     if (fixture_mode) {
-        expect_region(ipv4_xdb,
-                      xdb::ipv4,
-                      "1.2.3.4",
-                      "Example|Documentation|Fixture|Test ISP|EX");
-        expect_region(ipv6_xdb,
-                      xdb::ipv6,
-                      "2001:db8::1",
-                      "Example|Documentation|Fixture|Test ISP|EX");
+        const std::string reserved_region = "Reserved|Reserved|Reserved|0|ZZ";
+        const std::string example_region  = "Example|Documentation|Fixture|Test ISP|EX";
+
+        expect_region(ipv4_xdb, xdb::ipv4, "0.0.0.0", reserved_region);
+        expect_region(ipv4_xdb, xdb::ipv4, "1.2.3.0", example_region);
+        expect_region(ipv4_xdb, xdb::ipv4, "1.2.3.255", example_region);
+        expect_region(ipv4_xdb, xdb::ipv4, "1.2.4.0", reserved_region);
+
+        expect_region(ipv6_xdb, xdb::ipv6, "::", reserved_region);
+        expect_region(ipv6_xdb, xdb::ipv6, "2001:db8::", example_region);
+        expect_region(ipv6_xdb, xdb::ipv6, "2001:db8::ffff", example_region);
+        expect_region(ipv6_xdb, xdb::ipv6, "2001:db8::1:0", reserved_region);
     }
 
     return 0;

--- a/binding/cpp/test/make.cc
+++ b/binding/cpp/test/make.cc
@@ -2,6 +2,9 @@
 #include "../src/make.h"
 #include "../src/search.h"
 
+static_assert(sizeof(xdb::make_t) < 1024,
+              "make_t must keep its vector index off the stack");
+
 void test(const std::string& prompt,
           const std::string& filename_xdb,
           const std::string& filename_src,

--- a/binding/cpp/test/make.cc
+++ b/binding/cpp/test/make.cc
@@ -5,14 +5,16 @@
 static_assert(sizeof(xdb::make_t) < 1024,
               "make_t must keep its vector index off the stack");
 
-void test(const std::string& prompt,
-          const std::string& filename_xdb,
-          const std::string& filename_src,
-          int                version
+std::string join_path(const std::string& directory, const std::string& filename) {
+    return directory + "/" + filename;
+}
 
-) {
+void make_xdb(const std::string& prompt,
+              const std::string& source_path,
+              const std::string& xdb_path,
+              int                version) {
     std::cout << prompt;
-    xdb::make_t(filename_xdb, filename_src, version);
+    xdb::make_t(source_path, xdb_path, version);
 }
 
 void expect_region(const std::string& filename_xdb,
@@ -24,25 +26,36 @@ void expect_region(const std::string& filename_xdb,
         xdb::log_exit("generated xdb query failed for " + ip);
 }
 
-int main() {
-    test("生成 ipv4 的 xdb 文件, ",
-         "../../data/ipv4_source.txt",
-         "./ip2region_v4.xdb",
-         xdb::ipv4);
+int main(int argc, char* argv[]) {
+    if (argc != 1 && argc != 3)
+        xdb::log_exit("usage: make [source-directory output-directory]");
 
-    test("生成 ipv6 的 xdb 文件, ",
-         "../../data/ipv6_source.txt",
-         "./ip2region_v6.xdb",
-         xdb::ipv6);
+    const bool        fixture_mode = argc == 3;
+    const std::string source_dir   = fixture_mode ? argv[1] : "../../data";
+    const std::string output_dir   = fixture_mode ? argv[2] : ".";
+    const std::string ipv4_xdb     = join_path(output_dir, "ip2region_v4.xdb");
+    const std::string ipv6_xdb     = join_path(output_dir, "ip2region_v6.xdb");
 
-    expect_region("./ip2region_v4.xdb",
-                  xdb::ipv4,
-                  "1.2.3.4",
-                  "Australia|Queensland|Brisbane|0|AU");
-    expect_region("./ip2region_v6.xdb",
-                  xdb::ipv6,
-                  "2001:200:124::",
-                  "Japan|Tokyo|Asagaya-minami|WIDE Project|JP");
+    make_xdb("生成 ipv4 的 xdb 文件, ",
+             join_path(source_dir, "ipv4_source.txt"),
+             ipv4_xdb,
+             xdb::ipv4);
+
+    make_xdb("生成 ipv6 的 xdb 文件, ",
+             join_path(source_dir, "ipv6_source.txt"),
+             ipv6_xdb,
+             xdb::ipv6);
+
+    if (fixture_mode) {
+        expect_region(ipv4_xdb,
+                      xdb::ipv4,
+                      "1.2.3.4",
+                      "Example|Documentation|Fixture|Test ISP|EX");
+        expect_region(ipv6_xdb,
+                      xdb::ipv6,
+                      "2001:db8::1",
+                      "Example|Documentation|Fixture|Test ISP|EX");
+    }
 
     return 0;
 }


### PR DESCRIPTION
## changes

**本 PR 补齐了 C++ binding 在原生 Windows 环境中的构建能力**，并顺便修掉了之前跨平台编译过程中出现的 binary 解码与内存泄漏问题。

- `Refactor`: 为 C++ library、CLI 和测试程序新增更加跨平台、自动化的 CMake build script
- `Port`: 将仅适用于 POSIX 的文件访问与时间 API 替换为真正跨平台的实现，解除对 `arpa/inet.h`、`sys/time.h` 不必要的依赖
- `Fix`: 读取binary指针时，将每个 `char` 字节显式转换为 `unsigned char` 后再参与实际运算，避免发生Sign Extension问题。
- `Fix`: 把较大的 vector index buffer 从 stack 迁移到了heap，以免 Windows 默认栈空间不足。
- `Fix`: 修正 maker 测试中源数据路径与 xdb 输出路径的形参命名，使其真正意义上与 `make_t(src, dst)` 的实际调用顺序一致。

Closes #523 & Refs #523

## 效果

CMake 构建

```bash
cmake -S binding/cpp -B binding/cpp/build -DCMAKE_BUILD_TYPE=Release
cmake --build binding/cpp/build --parallel
ctest --test-dir binding/cpp/build --output-on-failure
```

也可以利用现有 Makefile

```bash
make -C binding/cpp test
make -C binding/cpp clean
```